### PR TITLE
BGF stability

### DIFF
--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -263,6 +263,7 @@ class BetaGeoFitter(BaseFitter):
 
         Returns: a scalar or array
         """
+        t /= self._scale
         r, alpha, a, b = self._unload_params('r', 'alpha', 'a', 'b')
         hyp = hyp2f1(r, b, a + b - 1, t / (alpha + t))
         return (a + b - 1) / (a - 1) * (1 - hyp * (alpha / (alpha + t)) ** r)
@@ -280,7 +281,9 @@ class BetaGeoFitter(BaseFitter):
 
         Returns: a scalar or array
         """
-        x, t_x = frequency / self._scale, recency / self._scale
+        t /= self._scale
+        x = frequency / self._scale 
+        t_x = recency / self._scale
         r, alpha, a, b = self._unload_params('r', 'alpha', 'a', 'b')
 
         hyp_term = hyp2f1(r + x, b + x, a + b + x - 1, t / (alpha + T + t))
@@ -307,6 +310,7 @@ class BetaGeoFitter(BaseFitter):
         """
         r, alpha, a, b = self._unload_params('r', 'alpha', 'a', 'b')
         frequency /= self._scale
+        recency /= self._scale
         T /= self._scale
         return 1. / (1 + (frequency > 0) * (a / (b + frequency - 1)) * ((alpha + T) / (alpha + recency)) ** (r + frequency))
 
@@ -325,6 +329,9 @@ class BetaGeoFitter(BaseFitter):
         max_frequency = max_frequency or int(self.data['frequency'].max())
         max_recency = max_recency or int(self.data['T'].max())
 
+        max_recency /= self._scale
+        max_frequency /= self._scale
+
         Z = np.zeros((max_recency + 1, max_frequency + 1))
         for i, t_x in enumerate(np.arange(max_recency + 1)):
             for j, x in enumerate(np.arange(max_frequency + 1)):
@@ -342,6 +349,7 @@ class BetaGeoFitter(BaseFitter):
         """
 
         r, alpha, a, b = self._unload_params('r', 'alpha', 'a', 'b')
+        t /= self._scale
 
         first_term = beta(a, b + x) / beta(a, b) * gamma(r + x) / gamma(r) / gamma(x + 1) * (alpha / (alpha + t)) ** r * (t / (alpha + t)) ** x
         if x > 0:

--- a/lifetimes/plotting.py
+++ b/lifetimes/plotting.py
@@ -14,8 +14,6 @@ __all__ = [
 
 def plot_period_transactions(model, max_frequency=7, **kwargs):
     from matplotlib import pyplot as plt
-
-    bins = kwargs.pop('bins', range(9))
     labels = kwargs.pop('label', ['Actual', 'Model'])
 
     n = model.data.shape[0]

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -158,4 +158,7 @@ def _fit(minimizing_function, frequency, recency, T, iterative_fitting, penalize
     return minimizing_params, np.min(ll)
 
 def _scale_time(age):
-    return age.max()/10.
+    if age.max() > 100:
+        return age.max()/10.
+    else:
+        return 1

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -145,7 +145,7 @@ def calculate_alive_path(model, transactions, datetime_col, t, freq='D'):
 def _fit(minimizing_function, frequency, recency, T, iterative_fitting, penalizer_coef, initial_params, disp):
     ll = []
     sols = []
-    methods = ['Powell', 'Nelder-Mead']
+    methods = ['Nelder-Mead', 'Powell']
 
     for i in range(iterative_fitting + 1):
         fit_method = methods[i % len(methods)]
@@ -156,3 +156,6 @@ def _fit(minimizing_function, frequency, recency, T, iterative_fitting, penalize
         sols.append(output.x)
     minimizing_params = sols[np.argmin(ll)]
     return minimizing_params, np.min(ll)
+
+def _scale_time(age):
+    return age.max()/10.

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -158,7 +158,9 @@ def _fit(minimizing_function, frequency, recency, T, iterative_fitting, penalize
     return minimizing_params, np.min(ll)
 
 def _scale_time(age):
-    if age.max() > 100:
-        return age.max()/10.
+    # create a scaler such that the maximum age is 100.
+    upper_bound = 100.
+    if age.max() > upper_bound:
+        return upper_bound/age.max() 
     else:
-        return 1
+        return 1.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 
 setup(name='Lifetimes',
-      version='0.1.4',
+      version='0.1.5',
       description='Measure customer lifetime value in Python',
       author='Cam Davidson-Pilon',
       author_email='cam.davidson.pilon@gmaillcom',

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -47,14 +47,15 @@ class TestPlotting():
         plt.show()
 
     def test_plot_customer_alive_history(self):
+        from matplotlib import pyplot as plt
 
         transaction_data = load_transaction_data()
         # yes I know this is using the wrong data, but I'm testing plotting here.
         id = 35
         days_since_birth = 200
         sp_trans = transaction_data.ix[transaction_data['id'] == id]
-        plot.figure()
+        plt.figure()
         plotting.plot_history_alive(bgf, days_since_birth, sp_trans, 'date')
-        plot.show()
+        plt.show()
 
 


### PR DESCRIPTION
BFG was having stability issues for inputs with high values for `frequency` and `T`. Mostly they were caused by underflow issues. This PR adds some corrections:

1. Scales input when they appear to large.
2. Smarter defaults for `nan` or `inf` occur. 

### To do

- [x] do I need to `_scale` the input variables to a method like `expected_number_of_purchases_up_to_time`? yes. 
