### PR TITLE
referencing scipy functions differently so they can be pickled

### DIFF
--- a/lifetimes/version.py
+++ b/lifetimes/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-__version__ = '0.1.6.1'
+__version__ = '0.1.6.2'


### PR DESCRIPTION
Importing binary scipy functions directly into a namespace causes instances of `BetaGeoFitter` and other classes to not be pickle-able. This pull request fixes that issue by importing at the Python level instead.