### PR TITLE
DOC: Dont use DataFrame.apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Another interesting matrix to look at is the probability of still being *alive*:
 Let's return to our customers and rank them from "highest expected purchases in the next period" to lowest. Models expose a method that will predict a customer's expected purchases in the next period using their history.
 
     t = 1
-    data['predicted_purchases'] = data.apply(lambda r: bgf.conditional_expected_number_of_purchases_up_to_time(t, r['frequency'], r['recency'], r['T']), axis=1)
+    data['predicted_purchases'] = bgf.conditional_expected_number_of_purchases_up_to_time(t, data['frequency'], data['recency'], data['T'])
     data.sort('predicted_purchases').tail(5)
     """
            frequency  recency      T        predicted_purchases


### PR DESCRIPTION
Quick doc change in the Readme. When computing the `conditional_expected_number_of_purchases_up_to_time` you used `data.apply(..., axis=1)` when we can just pass the arguments into `conditional_expected_number_of_purchases_up_to_time` and get the vectorization speedup:

```python
In [6]: %timeit data['predicted_purchases'] = data.apply(lambda r: bgf.conditional_expected_number_of_purchases_up_to_time(t, r['frequency'], r['recency'], r['T']), axis=1)
10 loops, best of 3: 90.1 ms per loop

In [7]: %timeit data['predicted_purchases2'] = bgf.conditional_expected_number_of_purchases_up_to_time(t, data['frequency'], data['recency'], data['T'])
100 loops, best of 3: 2.78 ms per loop

In [8]: (data.predicted_purchases == data.predicted_purchases2).all()
Out[8]: True
```

The performance difference is even bigger when the number of observations increases. I noticed a few `.apply`s in the code as well, not sure I'll have a chance to see if we can easily change those in the any time soon.

Thanks for the library!