### PR TITLE
Made some plotting calls compatible with matplotlib >=1.5

### DIFF
--- a/lifetimes/plotting.py
+++ b/lifetimes/plotting.py
@@ -104,7 +104,7 @@ def plot_frequency_recency_matrix(model, T=1, max_frequency=None, max_recency=No
     interpolation = kwargs.pop('interpolation', 'none')
 
     ax = plt.subplot(111)
-    ax.imshow(Z, interpolation=interpolation, **kwargs)
+    PCM = ax.imshow(Z, interpolation=interpolation, **kwargs)
     plt.xlabel("Customer's Historical Frequency")
     plt.ylabel("Customer's Recency")
     plt.title('Expected Number of Future Purchases for %d Unit%s of Time,'
@@ -113,8 +113,7 @@ def plot_frequency_recency_matrix(model, T=1, max_frequency=None, max_recency=No
     # turn matrix into square
     forceAspect(ax)
 
-    # necessary for colorbar to show up
-    PCM = ax.get_children()[2]
+    # plot colorbar beside matrix
     plt.colorbar(PCM, ax=ax)
 
     return ax
@@ -139,7 +138,7 @@ def plot_probability_alive_matrix(model, max_frequency=None, max_recency=None, *
     interpolation = kwargs.pop('interpolation', 'none')
 
     ax = plt.subplot(111)
-    ax.imshow(z, interpolation=interpolation, **kwargs)
+    PCM = ax.imshow(z, interpolation=interpolation, **kwargs)
     plt.xlabel("Customer's Historical Frequency")
     plt.ylabel("Customer's Recency")
     plt.title('Probability Customer is Alive,\nby Frequency and Recency of a Customer')
@@ -147,8 +146,7 @@ def plot_probability_alive_matrix(model, max_frequency=None, max_recency=None, *
     # turn matrix into square
     forceAspect(ax)
 
-    # necessary for colorbar to show up
-    PCM = ax.get_children()[2]
+    # plot colorbar beside matrix
     plt.colorbar(PCM, ax=ax)
 
     return ax
@@ -158,10 +156,15 @@ def plot_expected_repeat_purchases(model, **kwargs):
     from matplotlib import pyplot as plt
 
     ax = kwargs.pop('ax', None) or plt.subplot(111)
-    color_cycle = ax._get_lines.color_cycle
-
     label = kwargs.pop('label', None)
-    color = coalesce(kwargs.pop('c', None), kwargs.pop('color', None), next(color_cycle))
+
+    if plt.matplotlib.__version__ >= "1.5":
+        color_cycle = ax._get_lines.prop_cycler
+        color = coalesce(kwargs.pop('c', None), kwargs.pop('color', None), next(color_cycle)['color'])
+    else:
+        color_cycle = ax._get_lines.color_cycle
+        color = coalesce(kwargs.pop('c', None), kwargs.pop('color', None), next(color_cycle))
+
     max_T = model.data['T'].max()
 
     times = np.linspace(0, max_T, 100)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -37,7 +37,7 @@ class TestPlotting():
         plt.show()
 
     def test_plot_probability_alive_matrix(self):
-        print plt.matplotlib.__version__
+        from matplotlib import pyplot as plt
 
         plt.figure()
         plotting.plot_probability_alive_matrix(bgf)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -36,6 +36,17 @@ class TestPlotting():
 
         plt.show()
 
+    def test_plot_probability_alive_matrix(self):
+        print plt.matplotlib.__version__
+
+        plt.figure()
+        plotting.plot_probability_alive_matrix(bgf)
+
+        plt.figure()
+        plotting.plot_probability_alive_matrix(bgf, max_recency=100, max_frequency=50)
+
+        plt.show()
+
     def test_plot_expected_repeat_purchases(self):
         from matplotlib import pyplot as plt
 


### PR DESCRIPTION
Some of the plotting functions were broken for matplotlib >=1.5, because of some changes to matplotlibs internal API. This PR makes some changes to try to use the public-facing matplotlib API where applicable, or make version-dependent calls if necessary.

I have also added a test for plot_probability_alive_matrix.