### PR TITLE
iteritems() has been removed in python 3.x

### DIFF
--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -32,7 +32,7 @@ class BaseFitter():
 
     def _print_params(self):
         s = ""
-        for p, value in self.params_.iteritems():
+        for p, value in self.params_.items():
             s += "%s: %.2f, " % (p, value)
         return s.strip(', ')
 


### PR DESCRIPTION
Orderdict.items() should be compatible (at least in this case) with both python 2 and 3.