### PR TITLE
Fix issues with summary_data_from_transaction_data() when including monetary_values column

### DIFF
--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -7,6 +7,7 @@ from scipy.optimize import minimize
 pd.options.mode.chained_assignment = None
 
 __all__ = ['calibration_and_holdout_data',
+           'find_repeated_transactions',
            'summary_data_from_transaction_data',
            'calculate_alive_path']
 
@@ -70,17 +71,13 @@ def reduce_events_to_period(transactions, *aggregation_columns):
     return transactions.groupby(aggregation_columns, sort=False).agg(lambda r: 1)
 
 
-def summary_data_from_transaction_data(transactions, customer_id_col, datetime_col, monetary_value_col=None, datetime_format=None,
-                                       observation_period_end=datetime.today(), freq='D'):
+def find_repeated_transactions(transactions, customer_id_col, datetime_col, monetary_value_col=None, datetime_format=None,
+                               observation_period_end=datetime.today(), freq='D'):
     """
-    This transforms a Dataframe of transaction data of the form:
-
+    This takes a Dataframe of transaction data of the form:
         customer_id, datetime [, monetary_value]
-
-    to a Dataframe of the form:
-
-        customer_id, frequency, recency, T [, monetary_value]
-
+    and appends a column named 'repeated' to the transaction log which indicates which rows
+    are repeated transactions for that customer_id.
     Parameters:
         transactions: a Pandas DataFrame.
         customer_id_col: the column in transactions that denotes the customer_id
@@ -101,31 +98,93 @@ def summary_data_from_transaction_data(transactions, customer_id_col, datetime_c
 
     transactions = transactions[select_columns].copy()
 
-    def to_period(d):
-        return d.to_period(freq)
+    # make sure the date column uses datetime objects, and use Pandas' DateTimeIndex.to_period()
+    # to convert the column to a PeriodIndex which is useful for time-wise grouping and truncating
+    transactions[datetime_col] = pd.to_datetime(transactions[datetime_col], format=datetime_format)
+    transactions = transactions.set_index(datetime_col).to_period(freq)
 
-    transactions[datetime_col] = pd.to_datetime(transactions[datetime_col], format=datetime_format).map(to_period)
-    observation_period_end = to_period(pd.to_datetime(observation_period_end, format=datetime_format))
+    transactions = transactions.ix[(transactions.index <= observation_period_end)].reset_index()
 
-    transactions = transactions.ix[transactions[datetime_col] <= observation_period_end]
+    if monetary_value_col:
+        # when we have a monetary column, make sure to sum together any values in the same period
+        period_transactions = transactions.groupby([customer_id_col, datetime_col], sort=False, as_index=False).sum()
+    else:
+        period_transactions = reduce_events_to_period(transactions, *select_columns).reset_index()
 
-    # reduce all events per customer during the period to a single event:
-    period_transactions = reduce_events_to_period(transactions, *select_columns).reset_index(level=select_columns[1:])
+    # find all of the initial transactions for every customer
+    first_transactions = period_transactions.groupby(customer_id_col, sort=True, as_index=False).first()
+    first_transactions['first'] = True
 
-    # count all orders by customer.
-    customers = period_transactions[datetime_col].groupby(level=customer_id_col, sort=False).agg(['max', 'min', 'count'])
+    # join the first_transaction column to the transaction log
+    period_transactions = pd.merge(
+        period_transactions,
+        first_transactions[[customer_id_col, datetime_col, 'first']],
+        how="left",
+        on=[customer_id_col, datetime_col]
+    )
+    # boolean invert the 'first' column to give a column representing repeated transactions
+    period_transactions['repeated'] = ~(period_transactions['first'].fillna(False))
+    select_columns.append('repeated')
 
-    # subtract 1 from count, as we ignore their first order.
-    customers['frequency'] = customers['count'] - 1
+    return period_transactions[select_columns]
 
+
+def summary_data_from_transaction_data(transactions, customer_id_col, datetime_col, monetary_value_col=None, datetime_format=None,
+                                       observation_period_end=datetime.today(), freq='D'):
+    """
+    This transforms a Dataframe of transaction data of the form:
+        customer_id, datetime [, monetary_value]
+    to a Dataframe of the form:
+        customer_id, frequency, recency, T [, monetary_value]
+    Parameters:
+        transactions: a Pandas DataFrame.
+        customer_id_col: the column in transactions that denotes the customer_id
+        datetime_col: the column in transactions that denotes the datetime the purchase was made.
+        monetary_value_col: the columns in the transactions that denotes the monetary value of the transaction.
+            Optional, only needed for customer lifetime value estimation models.
+        observation_period_end: a string or datetime to denote the final date of the study. Events
+            after this date are truncated.
+        datetime_format: a string that represents the timestamp format. Useful if Pandas can't understand
+            the provided format.
+        freq: Default 'D' for days, 'W' for weeks, 'M' for months... etc. Full list here:
+            http://pandas.pydata.org/pandas-docs/stable/timeseries.html#dateoffset-objects
+    """
+    observation_period_end = pd.to_datetime(observation_period_end, format=datetime_format).to_period(freq)
+
+    # label all of the repeated transactions
+    repeated_transactions = find_repeated_transactions(
+        transactions,
+        customer_id_col,
+        datetime_col,
+        monetary_value_col,
+        datetime_format,
+        observation_period_end,
+        freq
+    )
+    # group together all transactions by customer_id and find each customers first and last transaction
+    customers = repeated_transactions.groupby(customer_id_col)[datetime_col].agg(['min', 'max'])
+    # count up all the repeated transactions for each customer
+    # by using a pivot_table, customers with zero repeated transactions are naturally accounted for
+    customers['frequency'] = pd.pivot_table(
+        repeated_transactions,
+        index=customer_id_col,
+        values='repeated',
+        aggfunc=np.sum
+    )
+    customers['recency'] = customers['max'] - customers['min']
     customers['T'] = (observation_period_end - customers['min'])
-    customers['recency'] = (customers['max'] - customers['min'])
 
     summary_columns = ['frequency', 'recency', 'T']
 
     if monetary_value_col:
-        customers['monetary_value'] = period_transactions.groupby(level=customer_id_col)[
-            monetary_value_col].mean()
+        # use another pivot_table to find the mean of each customer's repeated transaction valeus
+        customers['monetary_value'] = pd.pivot_table(
+            repeated_transactions,
+            index=customer_id_col,
+            columns='repeated',
+            values=[monetary_value_col],
+            aggfunc=np.mean
+        )[monetary_value_col][True].fillna(0)
         summary_columns.append('monetary_value')
 
     return customers[summary_columns].astype(float)
@@ -179,7 +238,7 @@ def _fit(minimizing_function, minimizing_function_args, iterative_fitting, initi
 
 def _scale_time(age):
     # create a scalar such that the maximum age is 10.
-    return 10./age.max()
+    return 10. / age.max()
 
 
 def _check_inputs(frequency, recency, T):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,6 +71,74 @@ def large_transaction_level_data_with_monetary_value():
     return pd.DataFrame(d, columns=['id', 'date', 'monetary_value'])
 
 
+def test_find_repeated_transactions_returns_correct_results(large_transaction_level_data):
+    today = '2015-02-07'
+    actual = utils.find_repeated_transactions(large_transaction_level_data, 'id', 'date', observation_period_end=today)
+    expected = pd.DataFrame([[1, pd.Period('2015-01-01', 'D'), False],
+                             [1, pd.Period('2015-02-06', 'D'), True],
+                             [2, pd.Period('2015-01-01', 'D'), False],
+                             [3, pd.Period('2015-01-01', 'D'), False],
+                             [3, pd.Period('2015-01-02', 'D'), True],
+                             [3, pd.Period('2015-01-05', 'D'), True],
+                             [4, pd.Period('2015-01-16', 'D'), False],
+                             [4, pd.Period('2015-02-02', 'D'), True],
+                             [4, pd.Period('2015-02-05', 'D'), True],
+                             [5, pd.Period('2015-01-16', 'D'), False],
+                             [5, pd.Period('2015-01-17', 'D'), True],
+                             [5, pd.Period('2015-01-18', 'D'), True],
+                             [6, pd.Period('2015-02-02', 'D'), False]], columns=['id','date','repeated'])
+    assert_frame_equal(actual, expected)
+
+
+def test_find_repeated_transactions_with_specific_non_daily_frequency(large_transaction_level_data):
+    today = '2015-02-07'
+    actual = utils.find_repeated_transactions(large_transaction_level_data, 'id', 'date', observation_period_end=today, freq='W')
+    expected = pd.DataFrame([[1, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), False],
+                             [1, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), True],
+                             [2, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), False],
+                             [3, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), False],
+                             [3, pd.Period('2015-01-05/2015-01-11', 'W-SUN'), True],
+                             [4, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), False],
+                             [4, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), True],
+                             [5, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), False],
+                             [6, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), False]], columns=['id','date','repeated'])
+    assert_frame_equal(actual, expected)
+
+
+def test_find_repeated_transactions_with_monetary_values(large_transaction_level_data_with_monetary_value):
+    today = '2015-02-07'
+    actual = utils.find_repeated_transactions(large_transaction_level_data_with_monetary_value, 'id', 'date', 'monetary_value', observation_period_end=today)
+    expected = pd.DataFrame([[1, pd.Period('2015-01-01', 'D'), 1, False],
+                             [1, pd.Period('2015-02-06', 'D'), 2, True],
+                             [2, pd.Period('2015-01-01', 'D'), 2, False],
+                             [3, pd.Period('2015-01-01', 'D'), 3, False],
+                             [3, pd.Period('2015-01-02', 'D'), 1, True],
+                             [3, pd.Period('2015-01-05', 'D'), 5, True],
+                             [4, pd.Period('2015-01-16', 'D'), 6, False],
+                             [4, pd.Period('2015-02-02', 'D'), 3, True],
+                             [4, pd.Period('2015-02-05', 'D'), 3, True],
+                             [5, pd.Period('2015-01-16', 'D'), 3, False],
+                             [5, pd.Period('2015-01-17', 'D'), 1, True],
+                             [5, pd.Period('2015-01-18', 'D'), 8, True],
+                             [6, pd.Period('2015-02-02', 'D'), 5, False]], columns=['id','date','monetary_value','repeated'])
+    assert_frame_equal(actual, expected)
+
+
+def test_find_repeated_transactions_with_monetary_values_with_specific_non_daily_frequency(large_transaction_level_data_with_monetary_value):
+    today = '2015-02-07'
+    actual = utils.find_repeated_transactions(large_transaction_level_data_with_monetary_value, 'id', 'date', 'monetary_value', observation_period_end=today, freq='W')
+    expected = pd.DataFrame([[1, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), 1, False],
+                             [1, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), 2, True],
+                             [2, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), 2, False],
+                             [3, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), 4, False],
+                             [3, pd.Period('2015-01-05/2015-01-11', 'W-SUN'), 5, True],
+                             [4, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), 6, False],
+                             [4, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), 6, True],
+                             [5, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), 12, False],
+                             [6, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), 5, False]], columns=['id','date','monetary_value','repeated'])
+    assert_frame_equal(actual, expected)
+
+
 def test_summary_data_from_transaction_data_returns_correct_results(transaction_level_data):
     today = '2015-02-07'
     actual = utils.summary_data_from_transaction_data(transaction_level_data, 'id', 'date', observation_period_end=today)
@@ -105,12 +173,12 @@ def test_summary_date_from_transaction_data_with_specific_non_daily_frequency(la
 def test_summary_date_from_transaction_with_monetary_values(large_transaction_level_data_with_monetary_value):
     today = '20150207'
     actual = utils.summary_data_from_transaction_data(large_transaction_level_data_with_monetary_value, 'id', 'date', monetary_value_col='monetary_value', observation_period_end=today)
-    expected = pd.DataFrame([[1, 1., 36., 37., 1.5],
-                             [2, 0.,  0., 37., 2],
+    expected = pd.DataFrame([[1, 1., 36., 37., 2],
+                             [2, 0.,  0., 37., 0],
                              [3, 2.,  4., 37., 3],
-                             [4, 2., 20., 22., 4],
-                             [5, 2.,  2., 22., 4],
-                             [6, 0.,  0.,  5., 5]], columns=['id', 'frequency', 'recency', 'T', 'monetary_value']).set_index('id')
+                             [4, 2., 20., 22., 3],
+                             [5, 2.,  2., 22., 4.5],
+                             [6, 0.,  0.,  5., 0]], columns=['id', 'frequency', 'recency', 'T', 'monetary_value']).set_index('id')
     assert_frame_equal(actual, expected)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,71 +71,73 @@ def large_transaction_level_data_with_monetary_value():
     return pd.DataFrame(d, columns=['id', 'date', 'monetary_value'])
 
 
-def test_find_repeated_transactions_returns_correct_results(large_transaction_level_data):
+def test_find_first_transactions_returns_correct_results(large_transaction_level_data):
     today = '2015-02-07'
-    actual = utils.find_repeated_transactions(large_transaction_level_data, 'id', 'date', observation_period_end=today)
-    expected = pd.DataFrame([[1, pd.Period('2015-01-01', 'D'), False],
-                             [1, pd.Period('2015-02-06', 'D'), True],
-                             [2, pd.Period('2015-01-01', 'D'), False],
-                             [3, pd.Period('2015-01-01', 'D'), False],
-                             [3, pd.Period('2015-01-02', 'D'), True],
-                             [3, pd.Period('2015-01-05', 'D'), True],
-                             [4, pd.Period('2015-01-16', 'D'), False],
-                             [4, pd.Period('2015-02-02', 'D'), True],
-                             [4, pd.Period('2015-02-05', 'D'), True],
-                             [5, pd.Period('2015-01-16', 'D'), False],
-                             [5, pd.Period('2015-01-17', 'D'), True],
-                             [5, pd.Period('2015-01-18', 'D'), True],
-                             [6, pd.Period('2015-02-02', 'D'), False]], columns=['id','date','repeated'])
+    actual = utils.find_first_transactions(large_transaction_level_data, 'id', 'date', observation_period_end=today)
+    expected = pd.DataFrame([[1, pd.Period('2015-01-01', 'D'), True],
+                             [1, pd.Period('2015-02-06', 'D'), False],
+                             [2, pd.Period('2015-01-01', 'D'), True],
+                             [3, pd.Period('2015-01-01', 'D'), True],
+                             [3, pd.Period('2015-01-02', 'D'), False],
+                             [3, pd.Period('2015-01-05', 'D'), False],
+                             [4, pd.Period('2015-01-16', 'D'), True],
+                             [4, pd.Period('2015-02-02', 'D'), False],
+                             [4, pd.Period('2015-02-05', 'D'), False],
+                             [5, pd.Period('2015-01-16', 'D'), True],
+                             [5, pd.Period('2015-01-17', 'D'), False],
+                             [5, pd.Period('2015-01-18', 'D'), False],
+                             [6, pd.Period('2015-02-02', 'D'), True]], columns=['id','date','first'])
     assert_frame_equal(actual, expected)
 
 
-def test_find_repeated_transactions_with_specific_non_daily_frequency(large_transaction_level_data):
+def test_find_first_transactions_with_specific_non_daily_frequency(large_transaction_level_data):
     today = '2015-02-07'
-    actual = utils.find_repeated_transactions(large_transaction_level_data, 'id', 'date', observation_period_end=today, freq='W')
-    expected = pd.DataFrame([[1, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), False],
-                             [1, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), True],
-                             [2, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), False],
-                             [3, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), False],
-                             [3, pd.Period('2015-01-05/2015-01-11', 'W-SUN'), True],
-                             [4, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), False],
-                             [4, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), True],
-                             [5, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), False],
-                             [6, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), False]], columns=['id','date','repeated'])
+    actual = utils.find_first_transactions(large_transaction_level_data, 'id', 'date', observation_period_end=today, freq='W')
+    expected = pd.DataFrame([[1, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), True],
+                             [1, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), False],
+                             [2, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), True],
+                             [3, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), True],
+                             [3, pd.Period('2015-01-05/2015-01-11', 'W-SUN'), False],
+                             [4, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), True],
+                             [4, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), False],
+                             [5, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), True],
+                             [6, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), True]],
+                            columns=['id','date','first'],
+                            index=actual.index) #we shouldn't really care about row ordering or indexing, but assert_frame_equals is strict about it
     assert_frame_equal(actual, expected)
 
 
-def test_find_repeated_transactions_with_monetary_values(large_transaction_level_data_with_monetary_value):
+def test_find_first_transactions_with_monetary_values(large_transaction_level_data_with_monetary_value):
     today = '2015-02-07'
-    actual = utils.find_repeated_transactions(large_transaction_level_data_with_monetary_value, 'id', 'date', 'monetary_value', observation_period_end=today)
-    expected = pd.DataFrame([[1, pd.Period('2015-01-01', 'D'), 1, False],
-                             [1, pd.Period('2015-02-06', 'D'), 2, True],
-                             [2, pd.Period('2015-01-01', 'D'), 2, False],
-                             [3, pd.Period('2015-01-01', 'D'), 3, False],
-                             [3, pd.Period('2015-01-02', 'D'), 1, True],
-                             [3, pd.Period('2015-01-05', 'D'), 5, True],
-                             [4, pd.Period('2015-01-16', 'D'), 6, False],
-                             [4, pd.Period('2015-02-02', 'D'), 3, True],
-                             [4, pd.Period('2015-02-05', 'D'), 3, True],
-                             [5, pd.Period('2015-01-16', 'D'), 3, False],
-                             [5, pd.Period('2015-01-17', 'D'), 1, True],
-                             [5, pd.Period('2015-01-18', 'D'), 8, True],
-                             [6, pd.Period('2015-02-02', 'D'), 5, False]], columns=['id','date','monetary_value','repeated'])
+    actual = utils.find_first_transactions(large_transaction_level_data_with_monetary_value, 'id', 'date', 'monetary_value', observation_period_end=today)
+    expected = pd.DataFrame([[1, pd.Period('2015-01-01', 'D'), 1, True],
+                             [1, pd.Period('2015-02-06', 'D'), 2, False],
+                             [2, pd.Period('2015-01-01', 'D'), 2, True],
+                             [3, pd.Period('2015-01-01', 'D'), 3, True],
+                             [3, pd.Period('2015-01-02', 'D'), 1, False],
+                             [3, pd.Period('2015-01-05', 'D'), 5, False],
+                             [4, pd.Period('2015-01-16', 'D'), 6, True],
+                             [4, pd.Period('2015-02-02', 'D'), 3, False],
+                             [4, pd.Period('2015-02-05', 'D'), 3, False],
+                             [5, pd.Period('2015-01-16', 'D'), 3, True],
+                             [5, pd.Period('2015-01-17', 'D'), 1, False],
+                             [5, pd.Period('2015-01-18', 'D'), 8, False],
+                             [6, pd.Period('2015-02-02', 'D'), 5, True]], columns=['id','date','monetary_value','first'])
     assert_frame_equal(actual, expected)
 
 
-def test_find_repeated_transactions_with_monetary_values_with_specific_non_daily_frequency(large_transaction_level_data_with_monetary_value):
+def test_find_first_transactions_with_monetary_values_with_specific_non_daily_frequency(large_transaction_level_data_with_monetary_value):
     today = '2015-02-07'
-    actual = utils.find_repeated_transactions(large_transaction_level_data_with_monetary_value, 'id', 'date', 'monetary_value', observation_period_end=today, freq='W')
-    expected = pd.DataFrame([[1, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), 1, False],
-                             [1, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), 2, True],
-                             [2, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), 2, False],
-                             [3, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), 4, False],
-                             [3, pd.Period('2015-01-05/2015-01-11', 'W-SUN'), 5, True],
-                             [4, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), 6, False],
-                             [4, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), 6, True],
-                             [5, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), 12, False],
-                             [6, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), 5, False]], columns=['id','date','monetary_value','repeated'])
+    actual = utils.find_first_transactions(large_transaction_level_data_with_monetary_value, 'id', 'date', 'monetary_value', observation_period_end=today, freq='W')
+    expected = pd.DataFrame([[1, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), 1, True],
+                             [1, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), 2, False],
+                             [2, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), 2, True],
+                             [3, pd.Period('2014-12-29/2015-01-04', 'W-SUN'), 4, True],
+                             [3, pd.Period('2015-01-05/2015-01-11', 'W-SUN'), 5, False],
+                             [4, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), 6, True],
+                             [4, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), 6, False],
+                             [5, pd.Period('2015-01-12/2015-01-18', 'W-SUN'), 12, True],
+                             [6, pd.Period('2015-02-02/2015-02-08', 'W-SUN'), 5, True]], columns=['id','date','monetary_value','first'])
     assert_frame_equal(actual, expected)
 
 


### PR DESCRIPTION
I've found two issues with the function summary_data_from_transaction_data() when including an optional monetary_values column:

1. transaction in the same period aren't reduced (summed) together,
2. all transactions are included in the average purchase amount, when generally these model are only concerned with repeated transactions/purchases.

The PR refactors summary_data_from_transaction_data() to address both of these issues (I refer to http://brucehardie.com/notes/022/RFM_summary_in_Excel.pdf and http://brucehardie.com/notes/025/gamma-gamma_calibration.xlsx for how I'm expecting monetary values to be processed).

I've also introduced a function find_repeated_transactions(), which explicitly groups transactions by period and labels repeated transactions. I've separated this functionality from summary_data_from_transaction_data() because I expect that it will be useful for other things like comparing model/actual transaction volume as a function of time.