### PR TITLE
Added the ModifiedBetaGammaFitter class and tests

### DIFF
--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -15,7 +15,7 @@ from lifetimes.generate_data import pareto_nbd_model, beta_geometric_nbd_model
 __all__ = ['BetaGeoFitter', 'ParetoNBDFitter', 'GammaGammaFitter', 'ModifiedBetaGeoFitter']
 
 
-class BaseFitter():
+class BaseFitter(object):
 
     def __repr__(self):
         classname = self.__class__.__name__

--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -491,7 +491,7 @@ class ModifiedBetaGeoFitter(BaseFitter):
 
     [1] Batislam, E.P., M. Denizel, A. Filiztekin (2007),
         "Empirical validation and comparison of models for customer base analysis,"
-        International Journal of Research in Marketing, 24 (3), 201–209.
+        International Journal of Research in Marketing, 24 (3), 201-209.
     [2] Wagner, U. and Hoppe D. (2008), "Erratum on the MBG/NBD Model," International Journal
         of Research in Marketing, 25 (3), 225-226.
 

--- a/lifetimes/generate_data.py
+++ b/lifetimes/generate_data.py
@@ -114,7 +114,7 @@ def modified_beta_geometric_nbd_model(T, r, alpha, a, b, size=1):
     (http://brucehardie.com/papers/bgnbd_2004-04-20.pdf)
     [2] Batislam, E.P., M. Denizel, A. Filiztekin (2007),
         "Empirical validation and comparison of models for customer base analysis,"
-        International Journal of Research in Marketing, 24 (3), 201–209.
+        International Journal of Research in Marketing, 24 (3), 201-209.
     """
     if type(T) in [float, int]:
         T = T * np.ones(size)

--- a/lifetimes/generate_data.py
+++ b/lifetimes/generate_data.py
@@ -40,7 +40,7 @@ def beta_geometric_nbd_model(T, r, alpha, a, b, size=1):
         # hacky until I can find something better
         times = []
         next_purchase_in = stats.expon.rvs(scale=1. / l)
-        alive = True 
+        alive = True
         while (np.sum(times) + next_purchase_in < T[i]) and alive:
             times.append(next_purchase_in)
             next_purchase_in = stats.expon.rvs(scale=1. / l)
@@ -96,5 +96,51 @@ def pareto_nbd_model(T, r, alpha, s, beta, size=1):
 
         times = np.array(times).cumsum()
         df.ix[i] = len(times), np.max(times if times.shape[0] > 0 else 0), T[i], l, mu, time_of_death > T[i], i
+
+    return df.set_index('customer_id')
+
+
+def modified_beta_geometric_nbd_model(T, r, alpha, a, b, size=1):
+    """
+    Generate artificial data according to the MBG/NBD model. See [1,2] for model details
+    Parameters:
+        T: scalar or array, the length of time observing new customers.
+        r, alpha, a, b: scalars, represening parameters in the model. See [1,2]
+        size: the number of customers to generate
+    Returns:
+        DataFrame, with index as customer_ids and the following columns:
+        'frequency', 'recency', 'T', 'lambda', 'p', 'alive', 'customer_id'
+    [1]: '"Counting Your Customers" the Easy Way: An Alternative to the Pareto/NBD Model'
+    (http://brucehardie.com/papers/bgnbd_2004-04-20.pdf)
+    [2] Batislam, E.P., M. Denizel, A. Filiztekin (2007),
+        "Empirical validation and comparison of models for customer base analysis,"
+        International Journal of Research in Marketing, 24 (3), 201–209.
+    """
+    if type(T) in [float, int]:
+        T = T * np.ones(size)
+    else:
+        T = np.asarray(T)
+
+    probability_of_post_purchase_death = stats.beta.rvs(a, b, size=size)
+    lambda_ = stats.gamma.rvs(r, scale=1. / alpha, size=size)
+
+    columns = ['frequency', 'recency', 'T', 'lambda', 'p', 'alive', 'customer_id']
+    df = pd.DataFrame(np.zeros((size, len(columns))), columns=columns)
+
+    for i in range(size):
+        p = probability_of_post_purchase_death[i]
+        l = lambda_[i]
+
+        # hacky until I can find something better
+        times = []
+        next_purchase_in = stats.expon.rvs(scale=1. / l)
+        alive = np.random.random() > p  # essentially the difference between this model and BG/NBD
+        while (np.sum(times) + next_purchase_in < T[i]) and alive:
+            times.append(next_purchase_in)
+            next_purchase_in = stats.expon.rvs(scale=1. / l)
+            alive = np.random.random() > p
+
+        times = np.array(times).cumsum()
+        df.ix[i] = len(times), np.max(times if times.shape[0] > 0 else 0), T[i], l, p, alive, i
 
     return df.set_index('customer_id')

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -171,6 +171,109 @@ class TestBetaGammaFitter():
         assert abs(bgf_with_large_inputs.conditional_probability_alive(1, scale*2, scale*10) - bgf.conditional_probability_alive(1, 2, 10)) < 10e-5
 
 
+class TestModifiedBetaGammaFitter():
+
+    def test_sum_of_scalar_inputs_to_negative_log_likelihood_is_equal_to_array(self):
+        mbgf = estimation.ModifiedBetaGeoFitter
+        x = np.array([1,3])
+        t_x = np.array([2,2])
+        t = np.array([5,6])
+        params = [1,1,1,1]
+        assert mbgf._negative_log_likelihood(params, np.array([x[0]]), np.array([t_x[0]]), np.array([t[0]]), 0) \
+             + mbgf._negative_log_likelihood(params, np.array([x[1]]), np.array([t_x[1]]), np.array([t[1]]), 0) \
+            == mbgf._negative_log_likelihood(params, x, t_x, t, 0)
+ 
+    def test_params_out_is_close_to_BTYDplus(self):
+        """ See https://github.com/mplatzer/BTYDplus """
+        mbfg = estimation.ModifiedBetaGeoFitter()
+        mbfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'], iterative_fitting=3)
+        expected = np.array([0.525, 6.183, 0.891, 1.614])
+        npt.assert_array_almost_equal(expected, np.array(mbfg._unload_params('r', 'alpha', 'a', 'b')), decimal=3)
+
+    def test_conditional_expectation_returns_same_value_as_Hardie_excel_sheet(self):
+        mbfg = estimation.ModifiedBetaGeoFitter()
+        mbfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+        x = 2
+        t_x = 30.43
+        T = 38.86
+        t = 39 
+        expected = 1.226
+        actual = mbfg.conditional_expected_number_of_purchases_up_to_time(t, x, t_x, T) 
+        assert abs(expected - actual) < 0.05
+
+    def test_expectation_returns_same_value_Hardie_excel_sheet(self):
+        mbfg = estimation.ModifiedBetaGeoFitter()
+        mbfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+
+        times = np.array([0.1429, 1.0, 3.00, 31.8571, 32.00, 78.00])
+        expected = np.array([0.0078 ,0.0532 ,0.1506 ,1.0405,1.0437, 1.8576])
+        actual = mbfg.expected_number_of_purchases_up_to_time(times)
+        npt.assert_allclose(actual, expected, rtol=0.05) 
+
+    def test_conditional_probability_alive_returns_lessthan_1_if_no_repeat_purchases(self):
+        mbfg = estimation.ModifiedBetaGeoFitter()
+        mbfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+
+        assert mbfg.conditional_probability_alive(0, 1, 1) < 1.0
 
 
+    def test_conditional_probability_alive_is_between_0_and_1(self):
+        mbfg = estimation.ModifiedBetaGeoFitter()
+        mbfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
 
+        for i in range(0, 100, 10):
+            for j in range(0, 100, 10):
+                for k in range(j, 100, 10):
+                    assert 0 <= mbfg.conditional_probability_alive(i, j, k) <= 1.0
+
+
+    def test_fit_method_allows_for_better_accuracy_by_using_iterative_fitting(self):
+        mbfg1 = estimation.ModifiedBetaGeoFitter()
+        mbfg2 = estimation.ModifiedBetaGeoFitter()
+
+        np.random.seed(0)
+        mbfg1.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+
+        np.random.seed(0)
+        mbfg2.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'], iterative_fitting=5)
+        assert mbfg1._negative_log_likelihood_ >= mbfg2._negative_log_likelihood_
+
+
+    def test_penalizer_term_will_shrink_coefs_to_0(self):
+        mbfg_no_penalizer = estimation.ModifiedBetaGeoFitter()
+        mbfg_no_penalizer.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+        params_1 = np.array(list(mbfg_no_penalizer.params_.values()))
+
+        mbfg_with_penalizer = estimation.ModifiedBetaGeoFitter(penalizer_coef=0.1)
+        mbfg_with_penalizer.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+        params_2 = np.array(list(mbfg_with_penalizer.params_.values()))
+        assert params_2.sum() < params_1.sum()
+
+        mbfg_with_more_penalizer = estimation.ModifiedBetaGeoFitter(penalizer_coef=100)
+        mbfg_with_more_penalizer.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'], iterative_fitting=5)
+        params_3 = np.array(list(mbfg_with_more_penalizer.params_.values()))
+        assert params_3.sum() < params_2.sum()
+
+
+    def test_conditional_probability_alive_matrix(self):
+        mbfg = estimation.ModifiedBetaGeoFitter()
+        mbfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+        Z = mbfg.conditional_probability_alive_matrix()
+        max_t = int(mbfg.data['T'].max())
+
+        for t_x in range(Z.shape[0]):
+            for x in range(Z.shape[1]):
+                assert Z[t_x][x] == mbfg.conditional_probability_alive(x, t_x, max_t)
+
+
+    def test_scaling_inputs_gives_same_or_similar_results(self):
+        mbgf = estimation.ModifiedBetaGeoFitter()
+        mbgf.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+
+        scale = 10
+        mbgf_with_large_inputs = estimation.ModifiedBetaGeoFitter()
+        mbgf_with_large_inputs.fit(cdnow_customers['frequency'], scale*cdnow_customers['recency'], scale*cdnow_customers['T'])
+        assert mbgf_with_large_inputs._scale < 1.
+
+        assert abs(mbgf_with_large_inputs.conditional_probability_alive(1, scale*1, scale*2) - mbgf.conditional_probability_alive(1, 1, 2)) < 10e-2
+        assert abs(mbgf_with_large_inputs.conditional_probability_alive(1, scale*2, scale*10) - mbgf.conditional_probability_alive(1, 2, 10)) < 10e-2

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -245,7 +245,7 @@ class TestModifiedBetaGammaFitter():
         params_1 = np.array(list(mbfg_no_penalizer.params_.values()))
 
         mbfg_with_penalizer = estimation.ModifiedBetaGeoFitter(penalizer_coef=0.1)
-        mbfg_with_penalizer.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+        mbfg_with_penalizer.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'], iterative_fitting=3)
         params_2 = np.array(list(mbfg_with_penalizer.params_.values()))
         assert params_2.sum() < params_1.sum()
 


### PR DESCRIPTION
This PR would add an implementation of the Modified BG/NBD model. See http://research.sabanciuniv.edu/20/1/stvkaf01939.doc

This model is very similar to the BG/NBD model except that it has the customers sampling dropout their drop-out probabilities immediately after their first transaction instead of after a repeat transaction. This means that P(alive) shouldn't be stuck at 1 for one-time only buyers. Apart from that difference, most of the estimates should be very similar to the BG/NBD model.

Due to the similarity between the two models, for this implementation I've reused a lot of the BetaGammaFitter code with modified coefficients. This ends up feeling like there is a lot of repetition and it is definitely a question if it would make sense to combine the two classes, or just leave them separated.