### PR TITLE
Removed duplicate reduce_events_to_period()

### DIFF
--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -71,10 +71,6 @@ def reduce_events_to_period(transactions, *aggregation_columns):
     return transactions.groupby(aggregation_columns, sort=False).agg(lambda r: 1)
 
 
-def reduce_events_to_period(transactions, *aggregation_columns):
-    return transactions.groupby(aggregation_columns, sort=False).agg(lambda r: 1)
-
-
 def find_first_transactions(transactions, customer_id_col, datetime_col, monetary_value_col=None, datetime_format=None,
                             observation_period_end=datetime.today(), freq='D'):
     """


### PR DESCRIPTION
A duplicate `reduce_events_to_period()` snuck in, probably from my last PR. It can be removed without consequence.