### PR TITLE
Fix matplotlib test config that broke travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - conda info -a
 
   # Should match requirements.txt
-  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy scipy pandas matplotlib pytest
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy scipy pandas matplotlib nose pytest
   - source activate test-environment
   - python setup.py install
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - conda info -a
 
   # Should match requirements.txt
-  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy scipy pandas pytest
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy scipy pandas matplotlib pytest
   - source activate test-environment
   - python setup.py install
   - pip install coveralls

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,6 +1,9 @@
 import os
 import pandas as pd
 import pytest
+
+import matplotlib
+matplotlib.use('AGG') # use a non-interactive backend
 from matplotlib import pyplot as plt
 
 from lifetimes import plotting


### PR DESCRIPTION
When adding  pytest-mpl tests (#51), I missed some travis-ci configurations to get the whole thing working. Specifically:
* had to change the matplotlib to a non-interactive backend so that it doesn't have to deal with DISPLAY problems
* explicitly include matplotlib in the travis test environment
* for some reason, the python 3.3 environment needs `nose` to be installed for some part of matplotlib to function properly...