### PR TITLE
Rework Gamma-Gamma model and CLV calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,13 +265,32 @@ At this point we can train our Gamma-Gamma submodel and predict the conditional,
     <lifetimes.GammaGammaFitter: fitted with 946 subjects, p: 6.25, q: 3.74, v: 15.45>
     """
     
-We can now produce the average CLV figure for our dataset as follows:
+We can now estimate the average transaction value:
+
+    print ggf.conditional_expected_average_profit(
+            summary_with_money_value['frequency'],
+            summary_with_money_value['monetary_value']
+        ).head()
+    """
+    customer_id
+    1     24.658616
+    2     18.911480
+    3     35.171003
+    4     35.171003
+    5     35.171003
+    6     71.462851
+    7     18.911480
+    8     35.171003
+    9     27.282408
+    10    35.171003
+    dtype: float64
+    """
 
     print "Expected conditional average profit: %s, Average profit: %s" % (
         ggf.conditional_expected_average_profit(
             summary_with_money_value['frequency'],
             summary_with_money_value['monetary_value']
-        ), 
+        ).mean(),
         summary_with_money_value[summary_with_money_value['frequency']>0]['monetary_value'].mean()
     )
     """
@@ -280,15 +299,32 @@ We can now produce the average CLV figure for our dataset as follows:
 
 While for computing the total CLV using the DCF method (https://en.wikipedia.org/wiki/Discounted_cash_flow) adjusting for cost of capital:
  
+    # refit the BG model to the summary_with_money_value dataset
+    bgf.fit(summary_with_money_value['frequency'], summary_with_money_value['recency'], summary_with_money_value['T'])
+
     print ggf.customer_lifetime_value(
         bgf, #the model to use to predict the number of future transactions
         summary_with_money_value['frequency'],
         summary_with_money_value['recency'],
         summary_with_money_value['T'],
         summary_with_money_value['monetary_value'],
-        time=12,
+        time=12, # months
         discount_rate=0.7
-    ) #74942.63
+    ).head(10)
+    """
+    customer_id
+    1      27.535074
+    2       3.568358
+    3       6.598023
+    4       6.598023
+    5       6.598023
+    6     210.596327
+    7       5.294988
+    8       6.598023
+    9      32.905051
+    10      6.598023
+    Name: clv, dtype: float64
+    """
 
 ## Questions? Comments? 
 

--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -120,7 +120,7 @@ class GammaGammaFitter(BaseFitter):
         Returns:
             Series object with customer ids as index and the estimated customer lifetime values as values
         """
-        adjusted_monetary_value = self.conditional_expected_average_profit(frequency, monetary_value).values  # use the Gamma-Gamma estimates for the monetary_values
+        adjusted_monetary_value = self.conditional_expected_average_profit(frequency, monetary_value)  # use the Gamma-Gamma estimates for the monetary_values
         return customer_lifetime_value(transaction_prediction_model, frequency, recency, T, adjusted_monetary_value, time, discount_rate)
 
 

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -251,3 +251,28 @@ def _check_inputs(frequency, recency, T):
     check_recency_is_less_than_T(recency, T)
     check_frequency_of_zero_implies_recency_of_zero(frequency, recency)
     check_all_frequency_values_are_integer_values(frequency)
+
+
+def customer_lifetime_value(transaction_prediction_model, frequency, recency, T, monetary_value, time=12, discount_rate=1):
+    """
+    This method computes the average lifetime value for a group of one or more customers.
+        transaction_prediction_model: the model to predict future transactions, literature uses
+            pareto/ndb but we can also use a different model like bg
+        frequency: the frequency vector of customers' purchases (denoted x in literature).
+        recency: the recency vector of customers' purchases (denoted t_x in literature).
+        T: the vector of customers' age (time since first purchase)
+        monetary_value: the monetary value vector of customer's purchases (denoted m in literature).
+        time: the lifetime expected for the user in months. Default: 12
+        discount_rate: the monthly adjusted discount rate. Default: 1
+
+    Returns:
+        Series object with customer ids as index and the estimated customer lifetime values as values
+    """
+    df = pd.DataFrame(index=frequency.index)
+    df['clv'] = 0
+
+    for i in range(30, (time * 30) + 1, 30):
+        df['clv'] = df['clv'] + monetary_value * (transaction_prediction_model.predict(i, frequency, recency, T)
+                                                  - transaction_prediction_model.predict(i - 30, frequency, recency, T)) / (1 + discount_rate)**(i / 30)
+
+    return df['clv']

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -268,11 +268,7 @@ def customer_lifetime_value(transaction_prediction_model, frequency, recency, T,
     Returns:
         Series object with customer ids as index and the estimated customer lifetime values as values
     """
-    try:
-        df = pd.DataFrame(index=frequency.index)
-    except AttributeError: # the case when we're passing floats or ints instead of pd.Series
-        df = pd.DataFrame(index=[0])
-
+    df = pd.DataFrame(index=frequency.index)
     df['clv'] = 0 # initialize the clv column to zeros
 
     for i in range(30, (time * 30) + 1, 30):

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -269,10 +269,10 @@ def customer_lifetime_value(transaction_prediction_model, frequency, recency, T,
         Series object with customer ids as index and the estimated customer lifetime values as values
     """
     df = pd.DataFrame(index=frequency.index)
-    df['clv'] = 0
+    df['clv'] = 0 # initialize the clv column to zeros
 
     for i in range(30, (time * 30) + 1, 30):
-        df['clv'] = df['clv'] + monetary_value * (transaction_prediction_model.predict(i, frequency, recency, T)
-                                                  - transaction_prediction_model.predict(i - 30, frequency, recency, T)) / (1 + discount_rate)**(i / 30)
+        df['clv'] += monetary_value * (transaction_prediction_model.predict(i, frequency, recency, T) - transaction_prediction_model.predict(i - 30, frequency, recency, T)) 
+        df['clv'] /= (1 + discount_rate)**(i / 30)
 
     return df['clv']

--- a/lifetimes/version.py
+++ b/lifetimes/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-__version__ = '0.1.6.4'
+__version__ = '0.2.0.0'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import pytest
 import pandas as pd 
 import numpy as np
 from pandas.util.testing import assert_frame_equal
+from numpy.testing import assert_almost_equal, assert_allclose
 
 from lifetimes import utils, BetaGeoFitter
 
@@ -242,6 +243,7 @@ def test_calculate_alive_path(example_transaction_data, example_summary_data, fi
     assert alive_path[0] == 1
     assert alive_path[T] == fitted_bg.conditional_probability_alive(frequency, recency, T)
 
+
 def test_check_inputs():
     freq, recency, T = np.array([0,1,2]), np.array([0, 1, 10]), np.array([5, 6, 15])
     assert utils._check_inputs(freq, recency, T) is None
@@ -263,10 +265,41 @@ def test_check_inputs():
 def test_summary_data_from_transaction_data_obeys_data_contraints(example_summary_data):
     assert utils._check_inputs(example_summary_data['frequency'], example_summary_data['recency'], example_summary_data['T']) is None
 
+
 def test_scale_time():
     max_T = 200.
     T = np.arange(max_T)
     assert utils._scale_time(T) == 10. / (max_T-1)
 
 
-
+def test_customer_lifetime_value_with_known_values(fitted_bg):
+    """
+    >>> print fitted_bg
+    <lifetimes.BetaGeoFitter: fitted with 5000 subjects, r: 0.16, alpha: 1.86, a: 1.85, b: 3.18>
+    >>> t = fitted_bg.data.head()
+    >>> t
+       frequency  recency    T
+       0          0        0  298
+       1          0        0  224
+       2          6      142  292
+       3          0        0  147
+       4          2        9  183
+    >>> print fitted_bg.predict(30, t['frequency'], t['recency'], t['T'])
+    0    0.016053
+    1    0.021171
+    2    0.030461
+    3    0.031686
+    4    0.001607
+    dtype: float64
+    """
+    t = fitted_bg.data.head()
+    expected = np.array([0.016053, 0.021171, 0.030461, 0.031686, 0.001607])
+    # discount_rate=0 means the clv will be the same as the predicted
+    clv_d0 = utils.customer_lifetime_value(fitted_bg, t['frequency'], t['recency'], t['T'], monetary_value=pd.Series([1,1,1,1,1]), time=1, discount_rate=0.)
+    assert_almost_equal(clv_d0.values, expected, decimal=5)
+    # discount_rate=1 means the clv will halve over a period
+    clv_d1 = utils.customer_lifetime_value(fitted_bg, t['frequency'], t['recency'], t['T'], monetary_value=pd.Series([1,1,1,1,1]), time=1, discount_rate=1.)
+    assert_almost_equal(clv_d1.values, expected/2., decimal=5)
+    # time=2, discount_rate=0 means the clv will be twice the initial
+    clv_t2_d0 = utils.customer_lifetime_value(fitted_bg, t['frequency'], t['recency'], t['T'], monetary_value=pd.Series([1,1,1,1,1]), time=2, discount_rate=0)
+    assert_allclose(clv_t2_d0.values, expected*2., atol=0.01)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -306,7 +306,3 @@ def test_customer_lifetime_value_with_known_values(fitted_bg):
     # time=2, discount_rate=1 means the clv will be twice the initial
     clv_t2_d1 = utils.customer_lifetime_value(fitted_bg, t['frequency'], t['recency'], t['T'], monetary_value=pd.Series([1,1,1,1,1]), time=2, discount_rate=1.)
     assert_allclose(clv_t2_d1.values, expected/2. + expected/4., rtol=0.1)
-    # pass in floats instead of series
-    clv_floats = utils.customer_lifetime_value(fitted_bg, 0, 0, 298, 1, time=1, discount_rate=0.)
-    expected = np.array([0.016053])
-    assert_almost_equal(clv_floats.values, expected, decimal=5)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -302,4 +302,11 @@ def test_customer_lifetime_value_with_known_values(fitted_bg):
     assert_almost_equal(clv_d1.values, expected/2., decimal=5)
     # time=2, discount_rate=0 means the clv will be twice the initial
     clv_t2_d0 = utils.customer_lifetime_value(fitted_bg, t['frequency'], t['recency'], t['T'], monetary_value=pd.Series([1,1,1,1,1]), time=2, discount_rate=0)
-    assert_allclose(clv_t2_d0.values, expected*2., atol=0.01)
+    assert_allclose(clv_t2_d0.values, expected*2., rtol=0.1)
+    # time=2, discount_rate=1 means the clv will be twice the initial
+    clv_t2_d1 = utils.customer_lifetime_value(fitted_bg, t['frequency'], t['recency'], t['T'], monetary_value=pd.Series([1,1,1,1,1]), time=2, discount_rate=1.)
+    assert_allclose(clv_t2_d1.values, expected/2. + expected/4., rtol=0.1)
+    # pass in floats instead of series
+    clv_floats = utils.customer_lifetime_value(fitted_bg, 0, 0, 298, 1, time=1, discount_rate=0.)
+    expected = np.array([0.016053])
+    assert_almost_equal(clv_floats.values, expected, decimal=5)


### PR DESCRIPTION
Please note that the PR has some BREAKING CHANGES! Specifically, it changes the output of `GammaGammaFitter.ggf.conditional_expected_average_profit()` and `customer_lifetime_value` to pandas Series objects.

Overall, this PR does the following:
* moves the customer lifetime value calculation to `utils.customer_lifetime_value()`, and changes `GammaGammaFitter.customer_lifetime_value()` to use this streamlined method
* de-aggregates `GammaGammaFitter.conditional_expected_average_profit` and `customer_lifetime_value()` as discussed above. This change makes the CLV API more flexible, for example, a user can now calculate the CLV of segments of their userbase by passing selections of their users, or easily calculate the total or mean CLV by using Pandas' Series `sum()` or `mean()` on the returned CLV series
* added a number of tests covering the Gamma-Gamma model and CLV calculation, as well as a couple BG/NBD functions that were outstanding
* updates README.md regarding the changes to the GG model and CLV calculation
* there are also some whitespace formatting changes that came from running formatter/linter in the Makefile