### PR TITLE
Change fit method

### DIFF
--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -261,16 +261,15 @@ class GammaGammaFitter(BaseFitter):
         p, q, v = self._unload_params('p', 'q', 'v')
         return (((q - 1) / (p * x + q - 1)) * (v * p / (q - 1))) + (p * x / (p * x + q - 1)) * m
 
-    def fit(self, frequency, monetary_value, iterative_fitting=5, initial_params=None, verbose=False):
+    def fit(self, frequency, monetary_value, iterative_fitting=4, initial_params=None, verbose=False):
         """
         This methods fits the data to the Gamma/Gamma model.
 
         Parameters:
             frequency: the frequency vector of customers' purchases (denoted x in literature).
             monetary_value: the monetary value vector of customer's purchases (denoted m in literature).
-            iterative_fitting: perform `iterative_fitting` additional fits to find the best
-                parameters for the model. Setting to 0 will improve performances but possibly
-                hurt estimates. This model is not very stable so we suggest >10 for best estimates evaluation.
+            iterative_fitting: perform iterative_fitting fits over random/warm-started initial params.
+                 This model is not very stable so we suggest >10 for best estimates evaluation.
             initial_params: set initial params for the iterative fitter.
             verbose: set to true to print out convergence diagnostics.
 
@@ -321,9 +320,7 @@ class ParetoNBDFitter(BaseFitter):
             frequency: the frequency vector of customers' purchases (denoted x in literature).
             recency: the recency vector of customers' purchases (denoted t_x in literature).
             T: the vector of customers' age (time since first purchase)
-            iterative_fitting: perform `iterative_fitting` additional fits to find the best
-                parameters for the model. Setting to 0 will improve performances but possibly
-                hurt estimates.
+            iterative_fitting: perform iterative_fitting fits over random/warm-started initial params
             initial_params: set initial params for the iterative fitter.
             verbose: set to true to print out convergence diagnostics.
 
@@ -497,9 +494,7 @@ class BetaGeoFitter(BaseFitter):
             frequency: the frequency vector of customers' purchases (denoted x in literature).
             recency: the recency vector of customers' purchases (denoted t_x in literature).
             T: the vector of customers' age (time since first purchase)
-            iterative_fitting: perform `iterative_fitting` additional fits to find the best
-                parameters for the model. Setting to 0 will improve performances but possibly
-                hurt estimates.
+            iterative_fitting: perform iterative_fitting fits over random/warm-started initial params
             initial_params: set the initial parameters for the fitter.
             verbose: set to true to print out convergence diagnostics.
 
@@ -678,9 +673,7 @@ class ModifiedBetaGeoFitter(BetaGeoFitter):
             frequency: the frequency vector of customers' purchases (denoted x in literature).
             recency: the recency vector of customers' purchases (denoted t_x in literature).
             T: the vector of customers' age (time since first purchase)
-            iterative_fitting: perform `iterative_fitting` additional fits to find the best
-                parameters for the model. Setting to 0 will improve performances but possibly
-                hurt estimates.
+            iterative_fitting: perform iterative_fitting fits over random/warm-started initial params
             initial_params: set the initial parameters for the fitter.
             verbose: set to true to print out convergence diagnostics.
 

--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -85,10 +85,10 @@ class BetaGeoBetaBinomFitter(BaseFitter):
 
     @staticmethod
     def _negative_log_likelihood(params, frequency, recency, n, n_custs, penalizer_coef=0):
+        penalizer_term = penalizer_coef * log(params).sum()
+        return -np.sum(BetaGeoBetaBinomFitter._loglikelihood(params, frequency, recency, n) * n_custs) + penalizer_term
 
-        return -np.sum(BetaGeoBetaBinomFitter._loglikelihood(params, frequency, recency, n) * n_custs) + penalizer_coef
-
-    def fit(self, frequency, recency, n, n_custs, verbose=False):
+    def fit(self, frequency, recency, n, n_custs, verbose=False, iterative_fitting=1):
         """
         Fit the BG/BB model.
 
@@ -114,7 +114,7 @@ class BetaGeoBetaBinomFitter(BaseFitter):
 
         params, self._negative_log_likelihood_ = _fit(self._negative_log_likelihood,
                                                       [frequency, recency, n, n_custs, self.penalizer_coef],
-                                                      0,
+                                                      iterative_fitting,
                                                       np.ones(4),
                                                       4,
                                                       verbose)
@@ -146,7 +146,7 @@ class BetaGeoBetaBinomFitter(BaseFitter):
         tx = self.data['recency']
         n = self.data['n']
 
-        params = self._unload_params('alpha','beta','gamma','delta')
+        params = self._unload_params('alpha', 'beta', 'gamma', 'delta')
         alpha, beta, gamma, delta = params
 
         p1 = 1 / exp(BetaGeoBetaBinomFitter._loglikelihood(params, x, tx, n))
@@ -223,7 +223,7 @@ class BetaGeoBetaBinomFitter(BaseFitter):
 
 class GammaGammaFitter(BaseFitter):
 
-    def __init__(self, penalizer_coef=0.):
+    def __init__(self, penalizer_coef=0.0):
         self.penalizer_coef = penalizer_coef
 
     @staticmethod
@@ -310,7 +310,7 @@ class GammaGammaFitter(BaseFitter):
 
 class ParetoNBDFitter(BaseFitter):
 
-    def __init__(self, penalizer_coef=0.):
+    def __init__(self, penalizer_coef=0.0):
         self.penalizer_coef = penalizer_coef
 
     def fit(self, frequency, recency, T, iterative_fitting=1, initial_params=None, verbose=False):
@@ -486,7 +486,7 @@ class BetaGeoFitter(BaseFitter):
 
     """
 
-    def __init__(self, penalizer_coef=0.):
+    def __init__(self, penalizer_coef=0.0):
         self.penalizer_coef = penalizer_coef
 
     def fit(self, frequency, recency, T, iterative_fitting=1, initial_params=None, verbose=False):
@@ -667,7 +667,7 @@ class ModifiedBetaGeoFitter(BetaGeoFitter):
 
     """
 
-    def __init__(self, penalizer_coef=0.):
+    def __init__(self, penalizer_coef=0.0):
         super(self.__class__, self).__init__(penalizer_coef)
 
     def fit(self, frequency, recency, T, iterative_fitting=1, initial_params=None, verbose=False):

--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -520,7 +520,7 @@ class BetaGeoFitter(BaseFitter):
                                                       iterative_fitting,
                                                       initial_params,
                                                       4,
-                                                      verbose, 
+                                                      verbose,
                                                       tol)
 
         self.params_ = OrderedDict(zip(['r', 'alpha', 'a', 'b'], params))

--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -88,7 +88,7 @@ class BetaGeoBetaBinomFitter(BaseFitter):
         penalizer_term = penalizer_coef * log(params).sum()
         return -np.sum(BetaGeoBetaBinomFitter._loglikelihood(params, frequency, recency, n) * n_custs) + penalizer_term
 
-    def fit(self, frequency, recency, n, n_custs, verbose=False, iterative_fitting=1):
+    def fit(self, frequency, recency, n, n_custs, verbose=False, tol=1e-4, iterative_fitting=1):
         """
         Fit the BG/BB model.
 
@@ -117,7 +117,8 @@ class BetaGeoBetaBinomFitter(BaseFitter):
                                                       iterative_fitting,
                                                       np.ones(4),
                                                       4,
-                                                      verbose)
+                                                      verbose, 
+                                                      tol)
         self.params_ = OrderedDict(zip(['alpha','beta','gamma','delta'], params))
         self.data = DataFrame(vconcat[frequency, recency, n, n_custs],
                               columns=['frequency','recency','n','n_custs'])
@@ -261,7 +262,7 @@ class GammaGammaFitter(BaseFitter):
         p, q, v = self._unload_params('p', 'q', 'v')
         return (((q - 1) / (p * x + q - 1)) * (v * p / (q - 1))) + (p * x / (p * x + q - 1)) * m
 
-    def fit(self, frequency, monetary_value, iterative_fitting=4, initial_params=None, verbose=False):
+    def fit(self, frequency, monetary_value, iterative_fitting=4, initial_params=None, verbose=False, tol=1e-4):
         """
         This methods fits the data to the Gamma/Gamma model.
 
@@ -281,7 +282,8 @@ class GammaGammaFitter(BaseFitter):
                                                       iterative_fitting,
                                                       initial_params,
                                                       3,
-                                                      verbose)
+                                                      verbose, 
+                                                      tol)
 
         self.data = DataFrame(vconcat[frequency, monetary_value], columns=['frequency', 'monetary_value'])
         self.params_ = OrderedDict(zip(['p', 'q', 'v'], params))
@@ -312,7 +314,7 @@ class ParetoNBDFitter(BaseFitter):
     def __init__(self, penalizer_coef=0.0):
         self.penalizer_coef = penalizer_coef
 
-    def fit(self, frequency, recency, T, iterative_fitting=1, initial_params=None, verbose=False):
+    def fit(self, frequency, recency, T, iterative_fitting=1, initial_params=None, verbose=False, tol=1e-4):
         """
         This methods fits the data to the Pareto/NBD model.
 
@@ -338,7 +340,8 @@ class ParetoNBDFitter(BaseFitter):
                                                       iterative_fitting,
                                                       initial_params,
                                                       4,
-                                                      verbose)
+                                                      verbose,
+                                                      tol)
 
         self.params_ = OrderedDict(zip(['r', 'alpha', 's', 'beta'], params))
         self.data = DataFrame(vconcat[frequency, recency, T], columns=['frequency', 'recency', 'T'])
@@ -486,7 +489,7 @@ class BetaGeoFitter(BaseFitter):
     def __init__(self, penalizer_coef=0.0):
         self.penalizer_coef = penalizer_coef
 
-    def fit(self, frequency, recency, T, iterative_fitting=1, initial_params=None, verbose=False):
+    def fit(self, frequency, recency, T, iterative_fitting=1, initial_params=None, verbose=False, tol=1e-4):
         """
         This methods fits the data to the BG/NBD model.
 
@@ -517,7 +520,8 @@ class BetaGeoFitter(BaseFitter):
                                                       iterative_fitting,
                                                       initial_params,
                                                       4,
-                                                      verbose)
+                                                      verbose, 
+                                                      tol)
 
         self.params_ = OrderedDict(zip(['r', 'alpha', 'a', 'b'], params))
         self.params_['alpha'] /= self._scale
@@ -665,7 +669,7 @@ class ModifiedBetaGeoFitter(BetaGeoFitter):
     def __init__(self, penalizer_coef=0.0):
         super(self.__class__, self).__init__(penalizer_coef)
 
-    def fit(self, frequency, recency, T, iterative_fitting=1, initial_params=None, verbose=False):
+    def fit(self, frequency, recency, T, iterative_fitting=1, initial_params=None, verbose=False, tol=1e-4):
         """
         This methods fits the data to the MBG/NBD model.
 
@@ -682,7 +686,7 @@ class ModifiedBetaGeoFitter(BetaGeoFitter):
             self, with additional properties and methods like params_ and predict
 
         """
-        super(self.__class__, self).fit(frequency, recency, T, iterative_fitting, initial_params, verbose)  # although the partent method is called, this class's _negative_log_likelihood is referenced
+        super(self.__class__, self).fit(frequency, recency, T, iterative_fitting, initial_params, verbose, tol)  # although the parent method is called, this class's _negative_log_likelihood is referenced
         self.generate_new_data = lambda size=1: modified_beta_geometric_nbd_model(T, *self._unload_params('r', 'alpha', 'a', 'b'), size=size)  # this needs to be reassigned from the parent method
         return self
 

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -222,7 +222,7 @@ def _fit(minimizing_function, minimizing_function_args, iterative_fitting, initi
     while success_count < iterative_fitting:
         fit_method = methods[total_count % len(methods)]
         params_init = np.random.exponential(2., size=params_size) if initial_params is None else initial_params
-        output = minimize(_func_caller, method=fit_method, tol=1e-6,
+        output = minimize(_func_caller, method=fit_method, tol=1e-4,
                           x0=params_init, args=(minimizing_function_args, minimizing_function), options={'disp': disp})
         if output.success:
             ll.append(output.fun)

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -209,7 +209,7 @@ def calculate_alive_path(model, transactions, datetime_col, t, freq='D'):
     return customer_history.apply(lambda row: model.conditional_probability_alive(row['frequency'], row['recency'], row['T']), axis=1)
 
 
-def _fit(minimizing_function, minimizing_function_args, iterative_fitting, initial_params, params_size, disp):
+def _fit(minimizing_function, minimizing_function_args, iterative_fitting, initial_params, params_size, disp, tol=1e-4):
     ll = []
     sols = []
     methods = ['Nelder-Mead', 'BFGS']
@@ -217,12 +217,15 @@ def _fit(minimizing_function, minimizing_function_args, iterative_fitting, initi
     def _func_caller(params, func_args, function):
         return function(params, *func_args)
 
+    if iterative_fitting <= 0:
+        raise ValueError("iterative_fitting parameter should be greater than 0 as of lifetimes v0.2.1")
+
     success_count = 0
     total_count = 0
     while success_count < iterative_fitting:
         fit_method = methods[total_count % len(methods)]
         params_init = np.random.exponential(2., size=params_size) if initial_params is None else initial_params
-        output = minimize(_func_caller, method=fit_method, tol=1e-4,
+        output = minimize(_func_caller, method=fit_method, tol=tol,
                           x0=params_init, args=(minimizing_function_args, minimizing_function), options={'disp': disp})
         if output.success:
             ll.append(output.fun)

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -224,7 +224,7 @@ def _fit(minimizing_function, minimizing_function_args, iterative_fitting, initi
     total_count = 0
     while success_count < iterative_fitting:
         fit_method = methods[total_count % len(methods)]
-        params_init = np.random.exponential(2., size=params_size) if initial_params is None else initial_params
+        params_init = np.random.normal(1.0, scale=0.05, size=params_size) if initial_params is None else initial_params
         output = minimize(_func_caller, method=fit_method, tol=tol,
                           x0=params_init, args=(minimizing_function_args, minimizing_function), options={'disp': disp})
         if output.success:

--- a/lifetimes/version.py
+++ b/lifetimes/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-__version__ = '0.2.0.0'
+__version__ = '0.2.1.0'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,6 @@ import numpy as np
 
 
 def pytest_runtest_setup(item):
-    seed = np.random.randint(1000)
+    seed = 868
     print("Seed used in np.random.seed(): %d" % seed)
     np.random.seed(seed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,6 @@ import numpy as np
 
 
 def pytest_runtest_setup(item):
-    seed = 868
+    seed = np.random.randint(1000)
     print("Seed used in np.random.seed(): %d" % seed)
     np.random.seed(seed)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -235,7 +235,7 @@ class TestBetaGammaFitter():
 
     def test_expectation_returns_same_value_Hardie_excel_sheet(self):
         bfg = estimation.BetaGeoFitter()
-        bfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+        bfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'], tol=1e-6)
 
         times = np.array([0.1429, 1.0, 3.00, 31.8571, 32.00, 78.00])
         expected = np.array([0.0078 ,0.0532 ,0.1506 ,1.0405,1.0437, 1.8576])
@@ -358,17 +358,17 @@ class TestModifiedBetaGammaFitter():
         x = 2
         t_x = 30.43
         T = 38.86
-        t = 39 
+        t = 39
         expected = 1.226
         actual = mbfg.conditional_expected_number_of_purchases_up_to_time(t, x, t_x, T) 
         assert abs(expected - actual) < 0.05
 
     def test_expectation_returns_same_value_Hardie_excel_sheet(self):
         mbfg = estimation.ModifiedBetaGeoFitter()
-        mbfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+        mbfg.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'], tol=1e-6)
 
         times = np.array([0.1429, 1.0, 3.00, 31.8571, 32.00, 78.00])
-        expected = np.array([0.0078 ,0.0532 ,0.1506 ,1.0405,1.0437, 1.8576])
+        expected = np.array([0.0078, 0.0532, 0.1506, 1.0405, 1.0437, 1.8576])
         actual = mbfg.expected_number_of_purchases_up_to_time(times)
         npt.assert_allclose(actual, expected, rtol=0.05) 
 

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -240,7 +240,7 @@ class TestBetaGammaFitter():
         times = np.array([0.1429, 1.0, 3.00, 31.8571, 32.00, 78.00])
         expected = np.array([0.0078 ,0.0532 ,0.1506 ,1.0405,1.0437, 1.8576])
         actual = bfg.expected_number_of_purchases_up_to_time(times)
-        npt.assert_array_almost_equal(actual, expected, decimal=3) 
+        npt.assert_array_almost_equal(actual, expected, decimal=3)
 
     def test_conditional_probability_alive_returns_1_if_no_repeat_purchases(self):
         bfg = estimation.BetaGeoFitter()

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -42,7 +42,6 @@ class TestBetaGeoBetaBinomFitter():
 
         # Expected probabilities for last year 1995-0 repeat, 1999-2 repeat, 2001-6 repeat
         expected = np.array([0.11, 0.59, 0.93])
-
         prob_list = np.zeros(3)
         prob_list[0] = (bbtf.data[(bbtf.data['frequency'] == 0) & (bbtf.data['recency'] == 0)]['prob_alive'])
         prob_list[1] = (bbtf.data[(bbtf.data['frequency'] == 2) & (bbtf.data['recency'] == 4)]['prob_alive'])
@@ -325,7 +324,6 @@ class TestBetaGammaFitter():
     def test_scaling_inputs_gives_same_or_similar_results(self):
         bgf = estimation.BetaGeoFitter()
         bgf.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
-
         scale = 10
         bgf_with_large_inputs = estimation.BetaGeoFitter()
         bgf_with_large_inputs.fit(cdnow_customers['frequency'], scale*cdnow_customers['recency'], scale*cdnow_customers['T'])
@@ -339,10 +337,10 @@ class TestModifiedBetaGammaFitter():
 
     def test_sum_of_scalar_inputs_to_negative_log_likelihood_is_equal_to_array(self):
         mbgf = estimation.ModifiedBetaGeoFitter
-        x = np.array([1,3])
-        t_x = np.array([2,2])
-        t = np.array([5,6])
-        params = [1,1,1,1]
+        x = np.array([1, 3])
+        t_x = np.array([2, 2])
+        t = np.array([5, 6])
+        params = [1, 1, 1, 1]
         assert mbgf._negative_log_likelihood(params, np.array([x[0]]), np.array([t_x[0]]), np.array([t[0]]), 0) \
              + mbgf._negative_log_likelihood(params, np.array([x[1]]), np.array([t_x[1]]), np.array([t[1]]), 0) \
             == mbgf._negative_log_likelihood(params, x, t_x, t, 0)
@@ -413,7 +411,7 @@ class TestModifiedBetaGammaFitter():
         params_2 = np.array(list(mbfg_with_penalizer.params_.values()))
         assert params_2.sum() < params_1.sum()
 
-        mbfg_with_more_penalizer = estimation.ModifiedBetaGeoFitter(penalizer_coef=100)
+        mbfg_with_more_penalizer = estimation.ModifiedBetaGeoFitter(penalizer_coef=1.)
         mbfg_with_more_penalizer.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'], iterative_fitting=5)
         params_3 = np.array(list(mbfg_with_more_penalizer.params_.values()))
         assert params_3.sum() < params_2.sum()
@@ -450,8 +448,7 @@ class TestModifiedBetaGammaFitter():
     def test_scaling_inputs_gives_same_or_similar_results(self):
         mbgf = estimation.ModifiedBetaGeoFitter()
         mbgf.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
-
-        scale = 10
+        scale = 10.
         mbgf_with_large_inputs = estimation.ModifiedBetaGeoFitter()
         mbgf_with_large_inputs.fit(cdnow_customers['frequency'], scale*cdnow_customers['recency'], scale*cdnow_customers['T'])
         assert mbgf_with_large_inputs._scale < 1.

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -165,7 +165,7 @@ class TestParetoNBDFitter():
     def test_expectation_returns_same_value_as_R_BTYD(self):
         """ From https://cran.r-project.org/web/packages/BTYD/BTYD.pdf """
         ptf = estimation.ParetoNBDFitter()
-        ptf.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])
+        ptf.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'], tol=1e-6)
 
         expected = np.array([0.00000000, 0.05077821, 0.09916088, 0.14542507, 0.18979930,
             0.23247466, 0.27361274, 0.31335159, 0.35181024, 0.38909211])

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -13,7 +13,7 @@ from lifetimes import utils
 
 bgf = BetaGeoFitter()
 cd_data = load_cdnow()
-bgf.fit(cd_data['frequency'], cd_data['recency'], cd_data['T'], iterative_fitting=0)
+bgf.fit(cd_data['frequency'], cd_data['recency'], cd_data['T'], iterative_fitting=1)
 
 @pytest.mark.plottest
 class TestPlotting():
@@ -27,7 +27,7 @@ class TestPlotting():
     @pytest.mark.mpl_image_compare(tolerance=30)
     def test_plot_period_transactions_parento(self):
         pnbd = ParetoNBDFitter()
-        pnbd.fit(cd_data['frequency'], cd_data['recency'], cd_data['T'], iterative_fitting=0)
+        pnbd.fit(cd_data['frequency'], cd_data['recency'], cd_data['T'], iterative_fitting=1)
         
         plt.figure()
         plotting.plot_period_transactions(pnbd)
@@ -36,7 +36,7 @@ class TestPlotting():
     @pytest.mark.mpl_image_compare(tolerance=30)
     def test_plot_period_transactions_mbgf(self):
         mbgf = ModifiedBetaGeoFitter()
-        mbgf.fit(cd_data['frequency'], cd_data['recency'], cd_data['T'], iterative_fitting=0)
+        mbgf.fit(cd_data['frequency'], cd_data['recency'], cd_data['T'], iterative_fitting=1)
         
         plt.figure()
         plotting.plot_period_transactions(mbgf)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ def example_summary_data(example_transaction_data):
 @pytest.fixture()
 def fitted_bg(example_summary_data):
     bg = BetaGeoFitter()
-    bg.fit(example_summary_data['frequency'], example_summary_data['recency'], example_summary_data['T'], iterative_fitting=1)
+    bg.fit(example_summary_data['frequency'], example_summary_data['recency'], example_summary_data['T'], iterative_fitting=1, tol=1e-6)
     return bg
 
 @pytest.fixture()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ def example_summary_data(example_transaction_data):
 @pytest.fixture()
 def fitted_bg(example_summary_data):
     bg = BetaGeoFitter()
-    bg.fit(example_summary_data['frequency'], example_summary_data['recency'], example_summary_data['T'], iterative_fitting=0)
+    bg.fit(example_summary_data['frequency'], example_summary_data['recency'], example_summary_data['T'], iterative_fitting=1)
     return bg
 
 @pytest.fixture()


### PR DESCRIPTION
- `penalizer_coef` was doing nothing  in BetaGeoBetaBinomFitter, so I fixed that
- removed `Powell`  as a fitter. It gave the same results as NM, and was significantly slower. 
- added a warm-start to the fitters: if the previous fitter converges, use the output as an initial input. 
- instead of just running `iterative_fitting` times, we will run until `iterative_fitting` successful convergences. This, while appears to slow down the entire _fit routine, combined with the above to changes, makes the `test_estimator.py` test suite 50% faster!

EDIT:
 - I'm also reducing the tolerance from `1e-6` to `1e-4`. I never care about such precision, so I'd rather have a faster run time than more precision I might never need. 
 - Also bumping the version, but I'll wait for your changes in https://github.com/CamDavidsonPilon/lifetimes/pull/70 before I upload to PyPI

cc @hhammond for review please 

### Running on 💄 with a fixed seed
#### branch
```
1 loop, best of 3: 2min 21s per loop
OrderedDict([('r', 0.51888231072581714), ('alpha', 21.222120157343589), ('a', 2.3424582901483939), ('b', 4.3620516233819249)])
3348411.23857
```

#### master
```
1 loop, best of 1: 6min 49s per loop
OrderedDict([('r', 0.51868238084360141), ('alpha', 21.209590272922487), ('a', 2.3439241385746037), ('b', 4.3625653897493084)])
3348758.63896
```