### PR TITLE
Check input values of GammaGammaFitter.fit

### DIFF
--- a/lifetimes/estimation.py
+++ b/lifetimes/estimation.py
@@ -109,7 +109,7 @@ class BetaGeoBetaBinomFitter(BaseFitter):
         frequency = asarray(frequency)
         recency = asarray(recency)
         n = asarray(n)
-        n_custs= asarray(n_custs)
+        n_custs = asarray(n_custs)
         _check_inputs(frequency, recency, n)
 
         params, self._negative_log_likelihood_ = _fit(self._negative_log_likelihood,
@@ -259,9 +259,9 @@ class GammaGammaFitter(BaseFitter):
         """
         This method computes the conditional expectation of the average profit per transaction
         for a group of one or more customers.
-            x: a vector containing the customers' frequencies. Defaults to the whole set of
+            frequency: a vector containing the customers' frequencies. Defaults to the whole set of
                 frequencies used for fitting the model.
-            m: a vector containing the customers' monetary values. Defaults to the whole set of
+            monetary_value: a vector containing the customers' monetary values. Defaults to the whole set of
                 monetary values used for fitting the model.
 
         Returns:
@@ -287,6 +287,8 @@ class GammaGammaFitter(BaseFitter):
         Returns:
             self, fitted and with parameters estimated
         """
+        _check_inputs(frequency, monetary_value=monetary_value)
+
         params, self._negative_log_likelihood_ = _fit(self._negative_log_likelihood,
                                                       [frequency, monetary_value, self.penalizer_coef],
                                                       iterative_fitting,

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -261,24 +261,16 @@ def _scale_time(age):
     return 10. / age.max()
 
 
-def _check_inputs(frequency, recency, T):
-
-    def check_recency_is_less_than_T(recency, T):
-        if np.any(recency > T):
-            raise ValueError("""Some values in recency vector are larger than T vector. This is impossible according to the model.""")
-
-    def check_frequency_of_zero_implies_recency_of_zero(frequency, recency):
-        ix = frequency == 0
-        if np.any(recency[ix] != 0):
-            raise ValueError("""There exist non-zero recency values when frequency is zero. This is impossible according to the model.""")
-
-    def check_all_frequency_values_are_integer_values(frequency):
-        if np.sum((frequency - frequency.astype(int)) ** 2) != 0:
-            raise ValueError("""There exist non-integer values in the frequency vector. This is impossible according to the model.""")
-
-    check_recency_is_less_than_T(recency, T)
-    check_frequency_of_zero_implies_recency_of_zero(frequency, recency)
-    check_all_frequency_values_are_integer_values(frequency)
+def _check_inputs(frequency, recency=None, T=None, monetary_value=None):
+    if recency is not None:
+        if T is not None and np.any(recency > T):
+            raise ValueError("Some values in recency vector are larger than T vector.")
+        if np.any(recency[frequency == 0] != 0):
+            raise ValueError("There exist non-zero recency values when frequency is zero.")
+    if np.sum((frequency - frequency.astype(int)) ** 2) != 0:
+        raise ValueError("There exist non-integer values in the frequency vector.")
+    if monetary_value is not None and np.any(monetary_value <= 0):
+        raise ValueError("There exist non-positive values in the monetary_value vector.")
 
 
 def customer_lifetime_value(transaction_prediction_model, frequency, recency, T, monetary_value, time=12, discount_rate=0.01):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -10,9 +10,6 @@ from lifetimes.datasets import load_cdnow, load_summary_data_with_monetary_value
 
 cdnow_customers = load_cdnow()
 cdnow_customers_with_monetary_value = load_summary_data_with_monetary_value()
-returning_cdnow_customers_with_monetary_value = cdnow_customers_with_monetary_value[
-    cdnow_customers_with_monetary_value['frequency'] > 0
-]
 donations = load_donations()
 
 class TestBetaGeoBetaBinomFitter():
@@ -88,6 +85,9 @@ class TestBetaGeoBetaBinomFitter():
 class TestGammaGammaFitter():
 
     def test_params_out_is_close_to_Hardie_paper(self):
+        returning_cdnow_customers_with_monetary_value = cdnow_customers_with_monetary_value[
+            cdnow_customers_with_monetary_value['frequency'] > 0
+        ]
         ggf = estimation.GammaGammaFitter()
         ggf.fit(
             returning_cdnow_customers_with_monetary_value['frequency'],

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -10,6 +10,9 @@ from lifetimes.datasets import load_cdnow, load_summary_data_with_monetary_value
 
 cdnow_customers = load_cdnow()
 cdnow_customers_with_monetary_value = load_summary_data_with_monetary_value()
+returning_cdnow_customers_with_monetary_value = cdnow_customers_with_monetary_value[
+    cdnow_customers_with_monetary_value['frequency'] > 0
+]
 donations = load_donations()
 
 class TestBetaGeoBetaBinomFitter():
@@ -87,8 +90,8 @@ class TestGammaGammaFitter():
     def test_params_out_is_close_to_Hardie_paper(self):
         ggf = estimation.GammaGammaFitter()
         ggf.fit(
-            cdnow_customers_with_monetary_value['frequency'],
-            cdnow_customers_with_monetary_value['monetary_value'],
+            returning_cdnow_customers_with_monetary_value['frequency'],
+            returning_cdnow_customers_with_monetary_value['monetary_value'],
             iterative_fitting=3
         )
         expected = np.array([6.25, 3.74, 15.44])
@@ -113,7 +116,10 @@ class TestGammaGammaFitter():
         ggf.params_ = OrderedDict({'p':6.25, 'q':3.74, 'v':15.44})
 
         bgf = estimation.BetaGeoFitter()
-        bgf.fit(cdnow_customers_with_monetary_value['frequency'], cdnow_customers_with_monetary_value['recency'], cdnow_customers_with_monetary_value['T'], iterative_fitting=3)
+        bgf.fit(cdnow_customers_with_monetary_value['frequency'],
+                cdnow_customers_with_monetary_value['recency'],
+                cdnow_customers_with_monetary_value['T'],
+                iterative_fitting=3)
 
         ggf_clv = ggf.customer_lifetime_value(
                 bgf,
@@ -128,7 +134,8 @@ class TestGammaGammaFitter():
                 cdnow_customers_with_monetary_value['frequency'],
                 cdnow_customers_with_monetary_value['recency'],
                 cdnow_customers_with_monetary_value['T'],
-                ggf.conditional_expected_average_profit(cdnow_customers_with_monetary_value['frequency'],cdnow_customers_with_monetary_value['monetary_value'])
+                ggf.conditional_expected_average_profit(cdnow_customers_with_monetary_value['frequency'],
+                                                        cdnow_customers_with_monetary_value['monetary_value'])
         )
         npt.assert_equal(ggf_clv.values, utils_clv.values)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -260,21 +260,29 @@ def test_calculate_alive_path(example_transaction_data, example_summary_data, fi
 
 
 def test_check_inputs():
-    freq, recency, T = np.array([0,1,2]), np.array([0, 1, 10]), np.array([5, 6, 15])
-    assert utils._check_inputs(freq, recency, T) is None
+    frequency = np.array([0, 1, 2])
+    recency = np.array([0, 1, 10])
+    T = np.array([5, 6, 15])
+    monetary_value = np.array([2.3, 490, 33.33])
+    assert utils._check_inputs(frequency, recency, T, monetary_value) is None
 
     with pytest.raises(ValueError):
         bad_recency = T + 1
-        utils._check_inputs(freq, bad_recency, T)
+        utils._check_inputs(frequency, bad_recency, T)
 
     with pytest.raises(ValueError):
         bad_recency = recency.copy()
         bad_recency[0] = 1
-        utils._check_inputs(freq, bad_recency, T)
+        utils._check_inputs(frequency, bad_recency, T)
 
     with pytest.raises(ValueError):
         bad_freq = np.array([0, 0.5, 2])
         utils._check_inputs(bad_freq, recency, T)
+
+    with pytest.raises(ValueError):
+        bad_monetary_value = monetary_value.copy()
+        bad_monetary_value[0] = 0
+        utils._check_inputs(frequency, recency, T, bad_monetary_value)
 
 
 def test_summary_data_from_transaction_data_obeys_data_contraints(example_summary_data):


### PR DESCRIPTION
Add check to ensure that monetary values passed into `GammaGammaFitter.fit` are all positive.

Background: I spent some time figuring out why I was getting negative value predictions from `GammaGammaFitter`, and it turned out that I was passing in customers with zero mean value. Checking it explicitly would prevent other users from making the same mistake.