### PR TITLE
Pin the pytest-mpl version to 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - source activate test-environment
   - python setup.py install
   - pip install coveralls
-  - pip install pytest-cov pytest-mpl
+  - pip install pytest-cov pytest-mpl==0.5
 # command to run tests
 script:
   - py.test --cov lifetimes --mpl --mpl-baseline-path tests/reference_plots/


### PR DESCRIPTION
Looks like the pytest-mpl plugin pushed some releases in late Nov, which appears to be what is breaking the travis build.

I couldn't figure out what the problem is with pytest-mpl v0.7, as it is one of those annoying problems that don't occur locally. So a simple fix for the moment is to pin pytest-mpl to v0.5, which should at least get the CI and coverage going again.