### PR TITLE
Port p_alive fix for Pareto_NBD from Theofilos BTYD repo.

### DIFF
--- a/lifetimes/fitters/pareto_nbd_fitter.py
+++ b/lifetimes/fitters/pareto_nbd_fitter.py
@@ -136,6 +136,9 @@ class ParetoNBDFitter(BaseFitter):
         From paper:
         http://brucehardie.com/notes/009/pareto_nbd_derivations_2005-11-05.pdf
 
+        Numerical optimization authored by Ricardo Pereira,
+        https://github.com/theofilos/BTYD/blob/master/pnbd.R#L284
+
         Parameters:
             frequency: a scalar: historical frequency of customer.
             recency: a scalar: historical recency of customer.
@@ -147,9 +150,19 @@ class ParetoNBDFitter(BaseFitter):
         x, t_x = frequency, recency
         r, alpha, s, beta = self._unload_params('r', 'alpha', 's', 'beta')
 
-        A_0 = np.exp(self._log_A_0([r, alpha, s, beta], x, t_x, T))
-        return 1. / (1. + (s / (r + s + x)) *
-                     (alpha + T) ** (r + x) * (beta + T) ** s * A_0)
+        A_0 = 0
+        if alpha >= beta:
+            F1 = hyp2f1(r + s + x, s + 1, r + s + x + 1, (alpha - beta)/(alpha + t_x))
+            F2 = hyp2f1(r + s + x, s + 1, r + s + x + 1, (alpha - beta)/(alpha + T))
+            X1 = F1 * ((alpha + T)/(alpha + t_x))**(r + x) * ((beta + T)/(alpha + t_x))**s
+            X2 = F2 * ((beta + T)/(alpha + T))**s
+        else:
+            F1 = hyp2f1(r + s + x, r + x, r + s + x + 1, (alpha - beta)/(beta + t_x))
+            F2 = hyp2f1(r + s + x, r + x, r + s + x + 1, (alpha - beta)/(beta + T))
+            X1 = F1 * ((alpha + T)/(beta + t_x))**(r + x) * ((beta + T)/(beta + t_x))**s
+            X2 = F2 * ((alpha + T)/(beta + T))**(r + x)
+            return (1 + s/(r + s + x) * (X1-X2))**(-1)
+        return (1 + s/(r + s + x) * (X1-X2))**(-1)
 
     def conditional_probability_alive_matrix(self, max_frequency=None,
                                              max_recency=None):

--- a/lifetimes/fitters/pareto_nbd_fitter.py
+++ b/lifetimes/fitters/pareto_nbd_fitter.py
@@ -150,19 +150,19 @@ class ParetoNBDFitter(BaseFitter):
         x, t_x = frequency, recency
         r, alpha, s, beta = self._unload_params('r', 'alpha', 's', 'beta')
 
-        A_0 = 0
-        if alpha >= beta:
-            F1 = hyp2f1(r + s + x, s + 1, r + s + x + 1, (alpha - beta)/(alpha + t_x))
-            F2 = hyp2f1(r + s + x, s + 1, r + s + x + 1, (alpha - beta)/(alpha + T))
-            X1 = F1 * ((alpha + T)/(alpha + t_x))**(r + x) * ((beta + T)/(alpha + t_x))**s
-            X2 = F2 * ((beta + T)/(alpha + T))**s
+        maxab = max(alpha, beta)
+        absab = abs(alpha - beta)
+        if alpha < beta:
+            param2 = r + x
         else:
-            F1 = hyp2f1(r + s + x, r + x, r + s + x + 1, (alpha - beta)/(beta + t_x))
-            F2 = hyp2f1(r + s + x, r + x, r + s + x + 1, (alpha - beta)/(beta + T))
-            X1 = F1 * ((alpha + T)/(beta + t_x))**(r + x) * ((beta + T)/(beta + t_x))**s
-            X2 = F2 * ((alpha + T)/(beta + T))**(r + x)
-            return (1 + s/(r + s + x) * (X1-X2))**(-1)
-        return (1 + s/(r + s + x) * (X1-X2))**(-1)
+            param2 = s + 1.
+
+        F0 = ((alpha + T)**(r + x)) * ((beta + T)**s)
+        F1 = hyp2f1(r + s + x, param2, r + s + x + 1., absab / (maxab + t_x)) / \
+            ((maxab + t_x)**(r + s + x))
+        F2 = hyp2f1(r + s + x, param2, r + s + x + 1., absab / (maxab + t_x)) / \
+            ((maxab + T)**(r + s + x))
+        return 1./(1. + (s/(r + s + x)) * F0 * (F1 - F2))
 
     def conditional_probability_alive_matrix(self, max_frequency=None,
                                              max_recency=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 scipy
 pandas>=0.19
-dill
+dill==0.2.7.1

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -314,6 +314,17 @@ class TestParetoNBDFitter():
         p_alive = ptf.conditional_probability_alive(26.00, 30.86, 31.00)
         assert abs(p_alive - 0.9979) < 0.001
 
+    def test_conditional_probability_alive_overflow_error(self):
+        ptf = estimation.ParetoNBDFitter()
+        ptf.params_ = OrderedDict(
+            zip(['r', 'alpha', 's', 'beta'],
+            [10.465, 7.98565181e-03, 3.0516, 2.820]))
+        freq = np.array([400., 500., 500.])
+        rec = np.array([5., 1., 4.])
+        age = np.array([6., 37., 37.])
+        assert all([r <= 1 and r >= 0 and not np.isinf(r) and not pd.isnull(r)
+                    for r in ptf.conditional_probability_alive(freq, rec, age)])
+
     def test_conditional_probability_alive_matrix(self, cdnow_customers):
         ptf = estimation.ParetoNBDFitter()
         ptf.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -311,7 +311,7 @@ class TestParetoNBDFitter():
         ptf.params_ = OrderedDict(
             zip(['r', 'alpha', 's', 'beta'],
             [0.5534, 10.5802, 0.6061, 11.6562]))
-        p_alive = nbd.conditional_probability_alive(26.00, 30.86, 31.00)
+        p_alive = ptf.conditional_probability_alive(26.00, 30.86, 31.00)
         assert abs(p_alive - 0.9979) < 0.001
 
     def test_conditional_probability_alive_matrix(self, cdnow_customers):

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -302,6 +302,18 @@ class TestParetoNBDFitter():
                 for t in np.arange(recency, 100, 10.):
                     assert 0.0 <= ptf.conditional_probability_alive(freq, recency, t) <= 1.0
 
+    def test_conditional_probability_alive(self, cdnow_customers):
+        """
+        Target taken from page 8,
+        https://cran.r-project.org/web/packages/BTYD/vignettes/BTYD-walkthrough.pdf
+        """
+        ptf = estimation.ParetoNBDFitter()
+        ptf.params_ = OrderedDict(
+            zip(['r', 'alpha', 's', 'beta'],
+            [0.5534, 10.5802, 0.6061, 11.6562]))
+        p_alive = nbd.conditional_probability_alive(26.00, 30.86, 31.00)
+        assert abs(p_alive - 0.9979) < 0.001
+
     def test_conditional_probability_alive_matrix(self, cdnow_customers):
         ptf = estimation.ParetoNBDFitter()
         ptf.fit(cdnow_customers['frequency'], cdnow_customers['recency'], cdnow_customers['T'])


### PR DESCRIPTION
I noticed two outstanding issues related to numerical optimization stability: https://github.com/CamDavidsonPilon/lifetimes/issues/19 and https://github.com/CamDavidsonPilon/lifetimes/issues/25#issuecomment-152871363. I thought to continue getting up to speed with this library, I'd try to knock out the remaining stability issue.

I wasn't familiar with using a hypergeometric series to improve stability, so this is really just a port of a fix I found in [Theofilos repository](https://github.com/theofilos/BTYD/commit/b9b89ed591858cf6cb9406c7393258f3492b7c79) (though I did start learning about hypergeometric series, very interesting!).

I'd like to add at least one or two tests, I'll ponder those tonight.