### PR TITLE
Fix runtime warning of log

### DIFF
--- a/lifetimes/fitters/beta_geo_fitter.py
+++ b/lifetimes/fitters/beta_geo_fitter.py
@@ -141,7 +141,7 @@ class BetaGeoFitter(BaseFitter):
 
         d = vconcat[ones_like(freq), (freq > 0)]
         A_4 = log(a) - log(b + where(freq == 0, 1, freq) - 1) - \
-            (r + freq) * log(rec + alpha)
+            (r + freq) * log(rec + alpha) if (a > 0 and (b + where(freq == 0, 1, freq) - 1) > 0 and (rec + alpha) > 0) else 0
         A_4[isnan(A_4) | isinf(A_4)] = 0
         penalizer_term = penalizer_coef * sum(np.asarray(params) ** 2)
         return -(A_1 + A_2 + misc.logsumexp(


### PR DESCRIPTION
Fixes the scenario when an invalid value is put in log

`/usr/local/lib/python3.5/site-packages/lifetimes/estimation.py:645: RuntimeWarning: invalid value encountered in log
  A_4 = log(a) - log(b + freq - 1) - (r + freq) * log(rec + alpha)`