### PR TITLE
Save model docs

### DIFF
--- a/docs/Save and load model.md
+++ b/docs/Save and load model.md
@@ -1,0 +1,35 @@
+## Save and load model
+
+When you have lots of data and training takes a lot of time option with saving and loading model could be useful. First you need fit model, then save it and load.
+
+### Fit model
+
+```python
+from lifetimes import BetaGeoFitter
+from lifetimes.datasets import load_cdnow_summary
+
+data = load_cdnow_summary(index_col=[0])
+bgf = BetaGeoFitter()
+bgf.fit(data['frequency'], data['recency'], data['T'])
+bgf
+"""<lifetimes.BetaGeoFitter: fitted with 2357 subjects, a: 0.79, alpha: 4.41, b: 2.43, r: 0.24>"""
+```
+
+### Saving model
+
+Model will be saved with [dill](https://github.com/uqfoundation/dill) to pickle object. Optional parameter `save_data` is used for saving data from model or not (default: `True`).
+
+```python
+bgf.save_model('bgf.pkl')
+```
+
+### Loading model
+
+Before loading you should initialize the model first and then use method `load_model`
+
+```python
+bgf_loaded = BetaGeoFitter()
+bgf_loaded.load_model('bgf.pkl')
+bgf_loaded
+"""<lifetimes.BetaGeoFitter: fitted with 2357 subjects, a: 0.79, alpha: 4.41, b: 2.43, r: 0.24>"""
+```

--- a/docs/Saving and loading model.md
+++ b/docs/Saving and loading model.md
@@ -1,6 +1,6 @@
-## Save and load model
+## Saving and loading model
 
-When you have lots of data and training takes a lot of time option with saving and loading model could be useful. First you need fit model, then save it and load.
+When you have lots of data and training takes a lot of time option with saving and loading model could be useful. First you need to fit the model, then save it and load.
 
 ### Fit model
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@
    :caption: Contents:
 
    Quickstart
+   Save and load model
    More examples and recipes
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@
    :caption: Contents:
 
    Quickstart
-   Save and load model
+   Saving and loading model
    More examples and recipes
 
 


### PR DESCRIPTION
Docs for current saving and loading model routine. Several thoughts about next:
- move `save_model` and `load_model` to function in something like `utils.py`
- add `to_json` and `to_yaml` functions to save only parameters of models
- add `save_data` to save only data

May be `save_model` could be rewritten to have an option how to save with three options:
- dill
- JSON
- YAML
