### PR TITLE
travis simplified, new python version 3.6-dev added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,15 @@
 language: python
+dist: trusty
 python:
    - "2.7"
    - "3.4"
    - "3.5"
    - "3.6"
+   - "3.6-dev" # 3.6 development branch
 before_install:
   - sudo apt-get update
-# See http://conda.pydata.org/docs/travis.html
 install:
-  # You may want to periodically update this, although the conda update
-  # conda line below will keep everything up-to-date.
-  # This saves us some downloading for this version
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update conda
-  # Useful for debugging any issues with conda
-  - conda info -a
-
-  # Should match requirements.txt
-  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy scipy pandas matplotlib nose pytest dill
-  - source activate test-environment
-  - python setup.py install
-  - pip install coveralls
-  - pip install pytest-cov pytest-mpl==0.5
+  - "pip install -r dev_requirements.txt"
 # command to run tests
 script:
   - py.test --cov lifetimes --mpl --mpl-baseline-path tests/reference_plots/


### PR DESCRIPTION
With python 3.7-dev there are [errors](https://travis-ci.org/CamDavidsonPilon/lifetimes/jobs/265838722), so excluded it. 
Also explicitly add dist trusty for .travis.yml because they are [planing](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) to change default distro to trusty.