### PR TITLE
Decouple ParetoNBD log-likelihood calculation from optimization step

### DIFF
--- a/lifetimes/fitters/pareto_nbd_fitter.py
+++ b/lifetimes/fitters/pareto_nbd_fitter.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from collections import OrderedDict
 
 import numpy as np
-from numpy import mean, log, exp, logaddexp, asarray, any as npany, c_ as vconcat
+from numpy import log, exp, logaddexp, asarray, any as npany, c_ as vconcat
 from pandas import DataFrame
 from scipy.special import gammaln, hyp2f1
 from scipy import misc

--- a/lifetimes/fitters/pareto_nbd_fitter.py
+++ b/lifetimes/fitters/pareto_nbd_fitter.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from collections import OrderedDict
 
 import numpy as np
-from numpy import log, exp, logaddexp, asarray, any as npany, c_ as vconcat
+from numpy import mean, log, exp, logaddexp, asarray, any as npany, c_ as vconcat
 from pandas import DataFrame
 from scipy.special import gammaln, hyp2f1
 from scipy import misc
@@ -141,10 +141,7 @@ class ParetoNBDFitter(BaseFitter):
                 rsf * log(q_1 * q_2))
 
     @staticmethod
-    def _negative_log_likelihood(params, freq, rec, T, penalizer_coef):
-
-        if npany(asarray(params) <= 0.):
-            return np.inf
+    def _conditional_log_likelihood(params, freq, rec, T):
 
         r, alpha, s, beta = params
         x = freq
@@ -157,8 +154,18 @@ class ParetoNBDFitter(BaseFitter):
         A_2 = logaddexp(-(r + x) * log(alpha + T) - s * log(beta + T),
                         log(s) + log_A_0 - log(r_s_x))
 
+        return A_1 + A_2
+
+    @staticmethod
+    def _negative_log_likelihood(params, freq, rec, T, penalizer_coef):
+
+        if npany(asarray(params) <= 0.):
+            return np.inf
+
+        conditional_log_likelihood = ParetoNBDFitter._conditional_log_likelihood(params, freq, rec, T)
         penalizer_term = penalizer_coef * sum(np.asarray(params) ** 2)
-        return -(A_1 + A_2).mean() + penalizer_term
+
+        return -conditional_log_likelihood.mean() + penalizer_term
 
     def conditional_expected_number_of_purchases_up_to_time(self, t, frequency,
                                                             recency, T):
@@ -189,7 +196,7 @@ class ParetoNBDFitter(BaseFitter):
         params = self._unload_params('r', 'alpha', 's', 'beta')
         r, alpha, s, beta = params
 
-        likelihood = -self._negative_log_likelihood(params, x, t_x, T, 0)
+        likelihood = self._conditional_log_likelihood(params, x, t_x, T)
         first_term = gammaln(r + x) - gammaln(r) + r * log(alpha) + s * \
             log(beta) - (r + x) * log(alpha + T) - s * log(beta + T)
         second_term = log(r + x) + log(beta + T) - log(alpha + T)


### PR DESCRIPTION
As discussed in #144 `ParetoNBDFitter.conditional_expected_number_of_purchases_up_to_time` uses the conditional log-likelihood to perform its calculation. However, the `_negative_log_likelihood` method actually marginalizes across all of the rows as part of the full negative log-likelihood calculation for the parameter optimization step.

To address this I've made a new function `_conditional_log_likelihood` which makes the intermediate calculation that both `_negative_log_likelihood` and `conditional_expected_number_of_purchases_up_to_time` require.