### PR TITLE
v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.9.1
+ - Added a data generation method, `generate_new_data` to `BetaGeoBetaBinomFitter`. @zscore
+ - Fixed a bug in `summary_data_from_transaction_data` that was casting values to `int` prematurely. This was solved by including a new param `freq_multiplier` to be used to scale the resulting durations. See #100 for the original issue.  @aprotopopov
+ - Performance and bug fixes in `utils.expected_cumulative_transactions`. @aprotopopov
+ - Fixed a bug in `utils.calculate_alive_path` that was causing a difference in values compared to `summary_from_transaction_data`. @DaniGate
+
 ### 0.9.0
  - fixed many of the numpy warnings as the result of fitting
  - added optional `initial_params` to all models

--- a/lifetimes/version.py
+++ b/lifetimes/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-__version__ = '0.9.0.0'
+__version__ = '0.9.1.0'


### PR DESCRIPTION
### 0.9.1
 - Added a data generation method, `generate_new_data` to `BetaGeoBetaBinomFitter`. @zscore
 - Fixed a bug in `summary_data_from_transaction_data` that was casting values to `int` prematurely. This was solved by including a new param `freq_multiplier` to be used to scale the resulting durations. See #100 for the original issue.  @aprotopopov
 - Performance and bug fixes in `utils.expected_cumulative_transactions`. @aprotopopov
 - Fixed a bug in `utils.calculate_alive_path` that was causing a difference in values compared to `summary_from_transaction_data`. @DaniGate