### PR TITLE
Add Q-Constraint to Avoid Negative CLTV Values

### DIFF
--- a/lifetimes/fitters/gamma_gamma_fitter.py
+++ b/lifetimes/fitters/gamma_gamma_fitter.py
@@ -51,10 +51,14 @@ class GammaGammaFitter(BaseFitter):
 
     @staticmethod
     def _negative_log_likelihood(params, frequency, avg_monetary_value,
-                                 penalizer_coef=0):
-        if any(i < 0 for i in params):
-            return np.inf
-
+                                 penalizer_coef=0, q_constraint=True):
+        if q_constraint:
+            if any(i < 0 for i in params) or params[1] < 1:
+                return np.inf
+        else:
+            if any(i < 0 for i in params):
+                return np.inf
+        
         p, q, v = params
 
         x = frequency
@@ -109,7 +113,7 @@ class GammaGammaFitter(BaseFitter):
 
     def fit(self, frequency, monetary_value, iterative_fitting=4,
             initial_params=None, verbose=False, tol=1e-4, index=None,
-            fit_method='Nelder-Mead', maxiter=2000, **kwargs):
+            fit_method='Nelder-Mead', maxiter=2000, q_constraint=True, **kwargs):
         """
         Fit the data to the Gamma/Gamma model.
 
@@ -150,7 +154,7 @@ class GammaGammaFitter(BaseFitter):
 
         params, self._negative_log_likelihood_ = _fit(
             self._negative_log_likelihood,
-            [frequency, monetary_value, self.penalizer_coef],
+            [frequency, monetary_value, self.penalizer_coef, q_constraint],
             iterative_fitting,
             initial_params,
             3,

--- a/lifetimes/fitters/gamma_gamma_fitter.py
+++ b/lifetimes/fitters/gamma_gamma_fitter.py
@@ -51,7 +51,7 @@ class GammaGammaFitter(BaseFitter):
 
     @staticmethod
     def _negative_log_likelihood(params, frequency, avg_monetary_value,
-                                 penalizer_coef=0, q_constraint=True):
+                                 penalizer_coef=0, q_constraint=False):
             
        
         if any(i < 0 for i in params):
@@ -113,7 +113,7 @@ class GammaGammaFitter(BaseFitter):
 
     def fit(self, frequency, monetary_value, iterative_fitting=4,
             initial_params=None, verbose=False, tol=1e-4, index=None,
-            fit_method='Nelder-Mead', maxiter=2000, q_constraint=True, **kwargs):
+            fit_method='Nelder-Mead', maxiter=2000, q_constraint=False, **kwargs):
         """
         Fit the data to the Gamma/Gamma model.
 
@@ -141,8 +141,8 @@ class GammaGammaFitter(BaseFitter):
             max iterations for optimizer in scipy.optimize.minimize will be
             overwritten if setted in kwargs.
         q_constraint: bool, optional
-            population mean will result in a negative value leading to negative CLV 
-            outputs when q < 1. If True, we penalize negative values of q to avoid this issue. 
+            when q < 1, population mean will result in a negative value 
+            leading to negative CLV outputs. If True, we penalize negative values of q to avoid this issue. 
         kwargs:
             key word arguments to pass to the scipy.optimize.minimize
             function as options dict

--- a/lifetimes/fitters/gamma_gamma_fitter.py
+++ b/lifetimes/fitters/gamma_gamma_fitter.py
@@ -52,15 +52,15 @@ class GammaGammaFitter(BaseFitter):
     @staticmethod
     def _negative_log_likelihood(params, frequency, avg_monetary_value,
                                  penalizer_coef=0, q_constraint=True):
-        if q_constraint:
-            if any(i < 0 for i in params) or params[1] < 1:
-                return np.inf
-        else:
-            if any(i < 0 for i in params):
-                return np.inf
-        
-        p, q, v = params
+            
+       
+        if any(i < 0 for i in params):
+            return np.inf
 
+        p, q, v = params
+        if q_constraint and q < 1:
+            return np.inf
+        
         x = frequency
         m = avg_monetary_value
 
@@ -140,6 +140,9 @@ class GammaGammaFitter(BaseFitter):
         maxiter : int, optional
             max iterations for optimizer in scipy.optimize.minimize will be
             overwritten if setted in kwargs.
+        q_constraint: bool, optional
+            population mean will result in a negative value leading to negative CLV 
+            outputs when q < 1. If True, we penalize negative values of q to avoid this issue. 
         kwargs:
             key word arguments to pass to the scipy.optimize.minimize
             function as options dict

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -267,6 +267,27 @@ class TestGammaGammaFitter():
         )
         assert (ggf.data.index == index).all() == False
 
+    def test_params_out_is_close_to_Hardie_paper_with_q_constraint(self, cdnow_customers_with_monetary_value):
+        returning_cdnow_customers_with_monetary_value = cdnow_customers_with_monetary_value[
+            cdnow_customers_with_monetary_value['frequency'] > 0
+        ]
+        ggf = estimation.GammaGammaFitter()
+        ggf.fit(
+            returning_cdnow_customers_with_monetary_value['frequency'],
+            returning_cdnow_customers_with_monetary_value['monetary_value'],
+            iterative_fitting=3,
+            q_constraint=True
+        )
+        expected = np.array([6.25, 3.74, 15.44])
+        npt.assert_array_almost_equal(expected, np.array(ggf._unload_params('p', 'q', 'v')), decimal=2)
+
+    def test_negative_log_likelihood_is_inf_when_q_constraint_true_and_q_lt_one(self):
+        frequency = 25
+        avg_monetary_value = 100
+        ggf = estimation.GammaGammaFitter()
+        assert np.isinf(ggf._negative_log_likelihood([6.25, -3.75, 15.44], frequency, avg_monetary_value, q_constraint=True))
+
+
 
 class TestParetoNBDFitter():
 


### PR DESCRIPTION
Fixes negative values that come out of the CLV by penalizing q < 1. 