### PR TITLE
Currently summary_data_from_transaction_data is broken when run with pandas==0.24

### DIFF
--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -259,9 +259,11 @@ def summary_data_from_transaction_data(transactions, customer_id_col, datetime_c
         customers['monetary_value'] = repeated_transactions.groupby(customer_id_col)[monetary_value_col].mean().fillna(0)
         summary_columns.append('monetary_value')
 
-    # fixes issue with pandas 0.24.*
-    customers['T'] = customers['T'].apply(lambda x: x.n)
-    customers['recency'] = customers['recency'].apply(lambda x: x.n)
+    # fixes issue with pandas 0.24.* where columns below are offsets
+    if customers['T'].dtype != float:
+        customers['T'] = customers['T'].apply(lambda x: x.n)
+    if customers['recency'].dtype != float:
+        customers['recency'] = customers['recency'].apply(lambda x: x.n)
     return customers[summary_columns].astype(float)
 
 

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -259,6 +259,9 @@ def summary_data_from_transaction_data(transactions, customer_id_col, datetime_c
         customers['monetary_value'] = repeated_transactions.groupby(customer_id_col)[monetary_value_col].mean().fillna(0)
         summary_columns.append('monetary_value')
 
+    # fixes issue with pandas 0.24.*
+    customers['T'] = customers['T'].apply(lambda x: x.n)
+    customers['recency'] = customers['recency'].apply(lambda x: x.n)
     return customers[summary_columns].astype(float)
 
 


### PR DESCRIPTION
Running

```
import pandas as pd
import lifetimes
import lifetimes.utils

df = pd.DataFrame([{'id': "1", "date": pd.to_datetime("2019-01-30")},
                   {'id': "1", "date": pd.to_datetime("2019-01-31")}])

lifetimes.utils.summary_data_from_transaction_data(df, 'id', 'date')
```

results in

```
~/py37/lib64/python3.7/site-packages/pandas/core/dtypes/cast.py in astype_nansafe(arr, dtype, copy, skipna)
    700     if copy or is_object_dtype(arr) or is_object_dtype(dtype):
    701         # Explicit copy, or required since NumPy can't view from / to object.
--> 702         return arr.astype(dtype, copy=True)
    703 
    704     return arr.view(dtype)

TypeError: float() argument must be a string or a number, not 'Day'
```

However with the casts proposed the issue goes away.