### PR TITLE
Log Likelihood Trackers for Convergence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ target/
 
 # VS Code
 .vscode/
+
+# Benchmarks Images
+benchmarks/images/

--- a/benchmarks/convergence_summary_graphs.py
+++ b/benchmarks/convergence_summary_graphs.py
@@ -5,7 +5,10 @@
 import sys
 
 import lifetimes
-from lifetimes.datasets import load_transaction_data
+from lifetimes.datasets import (
+    load_transaction_data,
+    load_cdnow_summary_data_with_monetary_value
+)
 from lifetimes.plotting import (
     plot_cumulative_transactions,
     plot_incremental_transactions,
@@ -42,21 +45,35 @@ print('Transaction Data Shape:', transaction_data.shape)
 print('Cal-Holdout Shape:', '\t', summary_cal_holdout.shape)
 print('')
 
+summary_with_money_value = load_cdnow_summary_data_with_monetary_value()
+summary_with_money_value.head()
+returning_customers_summary = summary_with_money_value[summary_with_money_value['frequency'] > 0]
+
+print('Correlation:', returning_customers_summary[['monetary_value', 'frequency']].corr())
+
 ####################################################################
 # Fitting the Model
 ####################################################################
 
-bgf = lifetimes.ParetoNBDFitter(
-    penalizer_coef = 0.2
-)
+# bgf = lifetimes.BetaGeoFitter(
+#     penalizer_coef = 0.2
+# )
 
+# bgf.fit(
+#     summary_cal_holdout['frequency_cal'], 
+#     summary_cal_holdout['recency_cal'], 
+#     summary_cal_holdout['T_cal']
+# )
+
+bgf = lifetimes.GammaGammaFitter(
+    penalizer_coef = 0
+)
 bgf.fit(
-    summary_cal_holdout['frequency_cal'], 
-    summary_cal_holdout['recency_cal'], 
-    summary_cal_holdout['T_cal']
+    returning_customers_summary['frequency'],
+    returning_customers_summary['monetary_value']
 )
 
-# print(bgf.summary) # not applicable for the Pareto/NBD fitter
+print(bgf.summary) # not applicable for the Pareto/NBD fitter
 
 print(bgf._negative_log_likelihood_)
 

--- a/benchmarks/convergence_summary_graphs.py
+++ b/benchmarks/convergence_summary_graphs.py
@@ -58,15 +58,15 @@ summary_cal_holdout = lifetimes.utils.calibration_and_holdout_data(
     observation_period_end = observation_period_end
 )
 
-print('Transaction Data Shape:', transaction_data.shape)
-print('Cal-Holdout Shape:', '\t', summary_cal_holdout.shape)
+print('Transaction Data Shape: {}'.format(transaction_data.shape))
+print('Cal-Holdout Shape: \t {}'.format(summary_cal_holdout.shape))
 print('')
 
 summary_with_money_value = load_cdnow_summary_data_with_monetary_value()
 summary_with_money_value.head()
 returning_customers_summary = summary_with_money_value[summary_with_money_value['frequency'] > 0]
 
-print('Correlation:', returning_customers_summary[['monetary_value', 'frequency']].corr())
+print('Correlation: {}'.format(returning_customers_summary[['monetary_value', 'frequency']].corr()))
 print('')
 
 ####################################################################
@@ -99,13 +99,13 @@ else:
 if fitter_type != 'ParetoNBDFitter':
     print(model.summary, '\n') # not applicable for the Pareto/NBD fitter
 
-print(model._negative_log_likelihood_, '\n')
+print('{}\n'.format(model._negative_log_likelihood_))
 
-print(model.ll_summary, '\n')
+print('{}\n'.format(model.ll_summary))
 
-print(model.solution_iter, '\n')
+print('{}\n'.format(model.solution_iter))
 
-print(model.solution_iter_summary, '\n')
+print('{}\n'.format(model.solution_iter_summary))
 
 ####################################################################
 # Plots
@@ -173,7 +173,7 @@ ax = plot_fitter_log_params(model = model)
 
 plt.savefig(plot_path + 'solution_iter' + img_type)
 
-print('log_params graph done', '\n')
+print('log_params graph done\n')
 
 ####################################################################
 # Transformed Parameters
@@ -244,7 +244,7 @@ axes = plot_fitter_params(model = model)
 
 plt.savefig(plot_path + 'solution_iter_summary' + img_type)
 
-print('transformed params graph done', '\n')
+print('transformed params graph done\n')
 
 ####################################################################
 # Graphs with the plotting.py file
@@ -261,10 +261,10 @@ ax = plot_fitter_log_params(model = model)
 
 plt.savefig(plot_path + 'solution_iter_lifetimes' + img_type)
 
-print('log_params graph done', '\n')
+print('log_params graph done\n')
 
 axes = plot_fitter_params(model = model)
 
 plt.savefig(plot_path + 'solution_iter_summary_lifetimes' + img_type)
 
-print('transformed params graph done', '\n')
+print('transformed params graph done\n')

--- a/benchmarks/convergence_summary_graphs.py
+++ b/benchmarks/convergence_summary_graphs.py
@@ -73,11 +73,13 @@ print('')
 # Fitting the Model
 ####################################################################
 
+# The beta_geo_binom needs a bit of a penalty to converge.
+penalizer_coef = 0 if fitter_type != 'BetaGeoBetaBinomFitter' else 0.2
 exec(
     '''model = lifetimes.{}(
-        penalizer_coef = 0
+        penalizer_coef = {}
     )
-    '''.format(fitter_type)
+    '''.format(fitter_type, penalizer_coef)
 )
 
 if fitter_type != 'GammaGammaFitter':

--- a/benchmarks/convergence_summary_graphs.py
+++ b/benchmarks/convergence_summary_graphs.py
@@ -46,7 +46,7 @@ print('')
 # Fitting the Model
 ####################################################################
 
-bgf = lifetimes.BetaGeoBetaBinomFitter(
+bgf = lifetimes.ParetoNBDFitter(
     penalizer_coef = 0.2
 )
 
@@ -56,7 +56,7 @@ bgf.fit(
     summary_cal_holdout['T_cal']
 )
 
-print(bgf.summary)
+# print(bgf.summary) # not applicable for the Pareto/NBD fitter
 
 print(bgf._negative_log_likelihood_)
 

--- a/benchmarks/convergence_summary_graphs.py
+++ b/benchmarks/convergence_summary_graphs.py
@@ -95,7 +95,8 @@ else:
         returning_customers_summary['monetary_value']
     )
 
-print(model.summary, '\n') # not applicable for the Pareto/NBD fitter
+if fitter_type != 'ParetoNBDFitter':
+    print(model.summary, '\n') # not applicable for the Pareto/NBD fitter
 
 print(model._negative_log_likelihood_, '\n')
 
@@ -118,13 +119,55 @@ img_type = '.svg'
 # log_params
 ####################################################################
 
-plt.plot(model.solution_iter)
+def plot_fitter_log_params(
+    model,
+    xlabel="iteration",
+    ylabel="value of the parameter",
+    title="Parameters Convergence before Any Transformations",
+    ax=None,
+    **kwargs
+):
+    """
+    Plots the fitter's approximated log of the parameters convergence.
 
-plt.xlabel('iteration')
-plt.ylabel('value of the parameter')
-plt.title('Parameters Convergence before Any Backwards Transformations')
+    Parameters
+    ----------
+    model: lifetimes model
+        A fitted lifetimes model, for now only for BG/NBD
+    title: str, optional
+        Figure title
+    xlabel: str, optional
+        Figure xlabel
+    ylabel: str, optional
+        Figure ylabel
+    ax: matplotlib.AxesSubplot, optional
+        Using user axes
+    kwargs
+        Passed into the pandas.DataFrame.plot command.
 
-plt.legend(model.params_names)
+    Returns
+    -------
+    axes: matplotlib.AxesSubplot
+    """
+
+    from matplotlib import pyplot as plt
+
+    if ax is None:
+        ax = plt.subplot(111)
+
+    plt.tight_layout()
+
+    plt.plot(model.solution_iter)
+
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+
+    plt.legend(model.params_names)
+
+    return ax
+
+ax = plot_fitter_log_params(model = model)
 
 plt.savefig(plot_path + 'solution_iter' + img_type)
 
@@ -134,21 +177,64 @@ print('log_params graph done', '\n')
 # Transformed Parameters
 ####################################################################
 
-fig = plt.figure(figsize = (15, 15))
+def plot_fitter_params(
+    model,
+    xlabel="iteration",
+    ylabel="value of the parameter",
+    title="Iterative Convergence of the Fitter's Parameters",
+    figsize=(15, 15),
+    ax=None,
+    **kwargs
+):
+    """
+    Plots the fitter's approximated parameters convergence.
 
-nrows, ncols = 2, 2
-subplot_counter = 1
-for param in model.solution_iter_summary.columns:
+    Parameters
+    ----------
+    model: lifetimes model
+        A fitted lifetimes model, for now only for BG/NBD
+    title: str, optional
+        Figure title
+    xlabel: str, optional
+        Figure xlabel
+    ylabel: str, optional
+        Figure ylabel
+    ax: matplotlib.AxesSubplot, optional
+        Using user axes
+    kwargs
+        Passed into the pandas.DataFrame.plot command.
 
-    plt.subplot(nrows, ncols, subplot_counter)
+    Returns
+    -------
+    axes: matplotlib.AxesSubplot
+    """
 
-    plt.plot(model.solution_iter_summary[param])
+    nrows, ncols = 2, 2
+    fig, axes = plt.subplots(nrows, ncols, figsize = figsize)
 
-    plt.xlabel('iteration')
-    plt.ylabel('value of the parameter')
-    plt.title('Iterative Convergence of Parameter {}'.format(param))
+    subplot_counter = 0
+    params = model.solution_iter_summary.columns
+    for i in range(nrows):
+        for j in range(ncols):
 
-    subplot_counter += 1
+            if subplot_counter < len(params):
+                ax = axes[i, j]
+                param = params[subplot_counter]
+
+                ax.plot(
+                    model.solution_iter_summary[param],
+                    label = param,
+                )
+
+                ax.set_xlabel('iteration')
+                ax.set_ylabel('value of the parameter')
+                ax.set_title('Iterative Convergence of Parameter {}'.format(param))
+
+                subplot_counter += 1
+
+    return axes
+
+axes = plot_fitter_params(model = model)
 
 plt.savefig(plot_path + 'solution_iter_summary' + img_type)
 

--- a/benchmarks/convergence_summary_graphs.py
+++ b/benchmarks/convergence_summary_graphs.py
@@ -89,7 +89,6 @@ if fitter_type != 'GammaGammaFitter':
         summary_cal_holdout['recency_cal'], 
         summary_cal_holdout['T_cal']
     )
-
 else:
 
     model.fit(

--- a/benchmarks/convergence_summary_graphs.py
+++ b/benchmarks/convergence_summary_graphs.py
@@ -125,6 +125,7 @@ def plot_fitter_log_params(
     ylabel="value of the parameter",
     title="Parameters Convergence before Any Transformations",
     ax=None,
+    figsize=(8, 6),
     **kwargs
 ):
     """
@@ -142,6 +143,8 @@ def plot_fitter_log_params(
         Figure ylabel
     ax: matplotlib.AxesSubplot, optional
         Using user axes
+    figsize: tuple
+        size of the image
     kwargs
         Passed into the pandas.DataFrame.plot command.
 
@@ -153,9 +156,7 @@ def plot_fitter_log_params(
     from matplotlib import pyplot as plt
 
     if ax is None:
-        ax = plt.subplot(111)
-
-    plt.tight_layout()
+        fig, ax = plt.subplots(1, 1, figsize = figsize)
 
     plt.plot(model.solution_iter)
 
@@ -201,6 +202,8 @@ def plot_fitter_params(
         Figure ylabel
     ax: matplotlib.AxesSubplot, optional
         Using user axes
+    figsize: tuple
+        size of the image
     kwargs
         Passed into the pandas.DataFrame.plot command.
 
@@ -208,6 +211,8 @@ def plot_fitter_params(
     -------
     axes: matplotlib.AxesSubplot
     """
+
+    from matplotlib import pyplot as plt
 
     nrows, ncols = 2, 2
     fig, axes = plt.subplots(nrows, ncols, figsize = figsize)
@@ -237,5 +242,28 @@ def plot_fitter_params(
 axes = plot_fitter_params(model = model)
 
 plt.savefig(plot_path + 'solution_iter_summary' + img_type)
+
+print('transformed params graph done', '\n')
+
+####################################################################
+# Graphs with the plotting.py file
+####################################################################
+
+# Simply copying the above plotting functions into plotting.py
+
+from lifetimes.plotting import (
+    plot_fitter_log_params,
+    plot_fitter_params
+)
+
+ax = plot_fitter_log_params(model = model)
+
+plt.savefig(plot_path + 'solution_iter_lifetimes' + img_type)
+
+print('log_params graph done', '\n')
+
+axes = plot_fitter_params(model = model)
+
+plt.savefig(plot_path + 'solution_iter_summary_lifetimes' + img_type)
 
 print('transformed params graph done', '\n')

--- a/benchmarks/test_ll.py
+++ b/benchmarks/test_ll.py
@@ -1,0 +1,114 @@
+####################################################################
+# Imports
+####################################################################
+
+import sys
+
+import lifetimes
+from lifetimes.datasets import load_transaction_data
+from lifetimes.plotting import (
+    plot_cumulative_transactions,
+    plot_incremental_transactions,
+    plot_period_transactions,
+    plot_calibration_purchases_vs_holdout_purchases
+)
+
+import pandas as pd
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+sns.set()
+
+####################################################################
+# Loading the Data
+####################################################################
+
+transaction_data = load_transaction_data()
+
+calibration_period_end = '2014-07-01'
+observation_period_end = '2014-12-31'
+
+beginning = pd.to_datetime(transaction_data['date'].min())
+
+summary_cal_holdout = lifetimes.utils.calibration_and_holdout_data(
+    transactions           = transaction_data, 
+    customer_id_col        = 'id', 
+    datetime_col           = 'date',
+    calibration_period_end = calibration_period_end,
+    observation_period_end = observation_period_end
+)
+
+print('Transaction Data Shape:', transaction_data.shape)
+print('Cal-Holdout Shape:', '\t', summary_cal_holdout.shape)
+print('')
+
+####################################################################
+# Fitting the Model
+####################################################################
+
+bgf = lifetimes.BetaGeoFitter(
+    penalizer_coef = 0.0
+)
+
+bgf.fit(
+    summary_cal_holdout['frequency_cal'], 
+    summary_cal_holdout['recency_cal'], 
+    summary_cal_holdout['T_cal']
+)
+
+print(bgf.summary)
+
+print(bgf._negative_log_likelihood_)
+
+print(bgf.ll_summary)
+
+print(bgf.solution_iter)
+
+print(bgf.solution_iter_summary)
+
+####################################################################
+# Plots
+####################################################################
+
+import matplotlib.pyplot as plt
+
+plot_path = 'benchmarks/images/'
+img_type = '.svg'
+
+####################################################################
+# log_params
+####################################################################
+
+plt.plot(bgf.solution_iter)
+
+plt.xlabel('iteration')
+plt.ylabel('value of the parameter')
+plt.title('Parameters Convergence before Any Backwards Transformations')
+
+plt.legend(bgf.params_names)
+
+plt.savefig(plot_path + 'solution_iter' + img_type)
+
+####################################################################
+# r, alpha, a, b
+####################################################################
+
+fig = plt.figure(figsize = (15, 15))
+
+nrows, ncols = 2, 2
+subplot_counter = 1
+for param in bgf.solution_iter_summary.columns:
+
+    plt.subplot(nrows, ncols, subplot_counter)
+
+    plt.plot(bgf.solution_iter_summary[param])
+
+    plt.xlabel('iteration')
+    plt.ylabel('value of the parameter')
+    plt.title('Iterative Convergence of Parameter {}'.format(param))
+
+    subplot_counter += 1
+
+plt.savefig(plot_path + 'solution_iter_summary' + img_type)
+
+

--- a/benchmarks/test_ll.py
+++ b/benchmarks/test_ll.py
@@ -46,8 +46,8 @@ print('')
 # Fitting the Model
 ####################################################################
 
-bgf = lifetimes.BetaGeoFitter(
-    penalizer_coef = 0.0
+bgf = lifetimes.BetaGeoBetaBinomFitter(
+    penalizer_coef = 0.2
 )
 
 bgf.fit(
@@ -110,5 +110,3 @@ for param in bgf.solution_iter_summary.columns:
     subplot_counter += 1
 
 plt.savefig(plot_path + 'solution_iter_summary' + img_type)
-
-

--- a/lifetimes/fitters/__init__.py
+++ b/lifetimes/fitters/__init__.py
@@ -258,6 +258,9 @@ class BaseFitter(object):
         df = pd.DataFrame(self.solution_iter, columns = self.params_names)
 
         df = np.exp(df)
-        df["alpha"] /= self._scale
+
+        BetaGeoBinom = "<class 'lifetimes.fitters.beta_geo_beta_binom_fitter.BetaGeoBetaBinomFitter'>"
+        if "alpha" in df.columns and str(type(self)) != BetaGeoBinom:
+            df["alpha"] /= self._scale
 
         return df

--- a/lifetimes/fitters/__init__.py
+++ b/lifetimes/fitters/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Base fitter for other classes."""
+
 import warnings
 
 warnings.simplefilter(action="ignore", category=FutureWarning)
@@ -13,10 +14,17 @@ from ..utils import _save_obj_without_attr, ConvergenceError
 
 
 class BaseFitter(object):
-    """Base class for fitters."""
+    """
+    Base class for fitters.
+    """
 
-    def __repr__(self):
-        """Representation of fitter."""
+    def __repr__(
+        self
+    ):
+        """
+        Representation of fitter.
+        """
+
         classname = self.__class__.__name__
         try:
             subj_str = " fitted with {:d} subjects,".format(self.data.shape[0])
@@ -31,12 +39,26 @@ class BaseFitter(object):
         except AttributeError:
             return "<lifetimes.{classname}>".format(classname=classname)
 
-    def _unload_params(self, *args):
+    def _unload_params(
+        self, 
+        *args
+    ):
+        """
+        Unloads parameters.
+        """
+
         if not hasattr(self, "params_"):
             raise ValueError("Model has not been fit yet. Please call the .fit" " method first.")
+        
         return [self.params_[x] for x in args]
 
-    def save_model(self, path, save_data=True, save_generate_data_method=True, values_to_save=None):
+    def save_model(
+        self, 
+        path, 
+        save_data=True, 
+        save_generate_data_method=True, 
+        values_to_save=None
+    ):
         """
         Save model with dill package.
 
@@ -52,12 +74,15 @@ class BaseFitter(object):
         values_to_save: list, optional
             Placeholders for original attributes for saving object. If None
             will be extended to attr_list length like [None] * len(attr_list)
-
         """
+
         attr_list = ["data" * (not save_data), "generate_new_data" * (not save_generate_data_method)]
         _save_obj_without_attr(self, attr_list, path, values_to_save=values_to_save)
 
-    def load_model(self, path):
+    def load_model(
+        self, 
+        path
+    ):
         """
         Load model with dill package.
 
@@ -65,24 +90,44 @@ class BaseFitter(object):
         ----------
         path: str
             From what path load model.
-
         """
+
         with open(path, "rb") as in_file:
             self.__dict__.update(dill.load(in_file).__dict__)
 
-    def _compute_variance_matrix(self):
+    def _compute_variance_matrix(
+        self
+    ):
+        """
+        Computes the Variance Matrix.
+        """
+
         params_ = self.params_
+
         return pd.DataFrame(
             (params_ ** 2).values * np.linalg.inv(self._hessian_) / self.data["weights"].sum(),
             columns=params_.index,
             index=params_.index,
         )
 
-    def _compute_standard_errors(self):
+    def _compute_standard_errors(
+        self
+    ):
+        """
+        Computes the Standard Errors.
+        """
+
         return np.sqrt(pd.Series(np.diag(self.variance_matrix_.values), index=self.params_.index))
 
-    def _compute_confidence_intervals(self):
-        inv_cdf_at_5_confidence = 1.96
+    def _compute_confidence_intervals(
+        self
+    ):
+        """
+        Computes the confidence intervals, at 95% confidence.
+        """
+
+        inv_cdf_at_5_confidence = 1.96 # 95% confidence
+
         return pd.DataFrame(
             {
                 "lower 95% bound": self.params_ - inv_cdf_at_5_confidence * self.standard_errors_,
@@ -91,11 +136,45 @@ class BaseFitter(object):
             index=self.params_.index,
         )
 
-    def _fit(self, minimizing_function_args, initial_params, params_size, disp, tol=1e-7, bounds=None, **kwargs):
+    def _fit(
+        self, 
+        minimizing_function_args, 
+        initial_params, 
+        params_size, 
+        disp, 
+        tol=1e-7, 
+        bounds=None, 
+        **kwargs
+    ):
+        """
+        Fits the model using ``scipy.optimize`` ``minimize()`` function.
+        """
+
         # set options for minimize, if specified in kwargs will be overwritten
         minimize_options = {}
         minimize_options["disp"] = disp
         minimize_options.update(kwargs)
+
+        self.solution_iter = []
+        def callback_solution_saver(
+            xk
+        ):
+            """
+            Instantiated inside ``scipy.optimize`` ``minimize()`` call 
+            inside the ``_fit()`` method.
+
+            Saves the solution at the fitter's ``solution_iter`` property.
+
+            Note that neither ``exp()`` nor scaling to ``alpha`` are applied here.
+            For those operations, use the ``solution_iter_summary`` property.
+
+            Parameters
+            ----------
+            xk : array-like
+                Solution at the current iteration.
+            """
+
+            self.solution_iter.append(xk.tolist())
 
         current_init_params = 0.1 * np.ones(params_size) if initial_params is None else initial_params
         output = minimize(
@@ -107,11 +186,17 @@ class BaseFitter(object):
             args=minimizing_function_args,
             options=minimize_options,
             bounds=bounds,
+            callback=callback_solution_saver
         )
+
         if output.success:
             hessian_ = hessian(self._negative_log_likelihood)(output.x, *minimizing_function_args)
+            self.nit = output.nit # Number of Iterations performed
+            
             return output.x, output.fun, hessian_
-        print(output)
+
+        # print(output)
+        
         raise ConvergenceError(
             dedent(
                 """
@@ -121,7 +206,9 @@ class BaseFitter(object):
         )
 
     @property
-    def summary(self):
+    def summary(
+        self
+    ):
         """
         Summary statistics describing the fit.
 
@@ -134,9 +221,43 @@ class BaseFitter(object):
         --------
         ``print_summary``
         """
+
         df = pd.DataFrame(index=self.params_.index)
         df["coef"] = self.params_
         df["se(coef)"] = self.standard_errors_
         df["lower 95% bound"] = self.confidence_intervals_["lower 95% bound"]
         df["upper 95% bound"] = self.confidence_intervals_["upper 95% bound"]
+        
+        return df
+
+    @property
+    def ll_summary(
+        self
+    ):
+        """
+        Log-Likelihood data for convergence evaluations.
+        """
+
+        ll_summary = {
+            'neg_log_likelihood' : [self._negative_log_likelihood_],
+            'num_it'             : [self.nit]
+        }
+
+        df = pd.DataFrame(ll_summary)
+
+        return df
+
+    @property
+    def solution_iter_summary(
+        self
+    ):
+        """
+        Essentially a wrapper for the Iterative Solutions (``self.solutions_iter``).
+        """
+
+        df = pd.DataFrame(self.solution_iter, columns = self.params_names)
+
+        df = np.exp(df)
+        df["alpha"] /= self._scale
+
         return df

--- a/lifetimes/fitters/beta_geo_beta_binom_fitter.py
+++ b/lifetimes/fitters/beta_geo_beta_binom_fitter.py
@@ -60,8 +60,12 @@ class BetaGeoBetaBinomFitter(BaseFitter):
     """
 
     def __init__(self, penalizer_coef=0.0):
-        """Initialization, set penalizer_coef."""
+        """
+        Initialization, set penalizer_coef.
+        """
+
         self.penalizer_coef = penalizer_coef
+        self.params_names = ["alpha", "beta", "gamma", "delta"]
 
     @staticmethod
     def _loglikelihood(params, x, tx, T):

--- a/lifetimes/fitters/beta_geo_fitter.py
+++ b/lifetimes/fitters/beta_geo_fitter.py
@@ -66,6 +66,7 @@ class BetaGeoFitter(BaseFitter):
         """
 
         self.penalizer_coef = penalizer_coef
+        self.params_names = ["r", "alpha", "a", "b"]
 
     def fit(
         self, 

--- a/lifetimes/fitters/gamma_gamma_fitter.py
+++ b/lifetimes/fitters/gamma_gamma_fitter.py
@@ -73,6 +73,7 @@ class GammaGammaFitter(BaseFitter):
         """
 
         self.penalizer_coef = penalizer_coef
+        self.params_names = ["p", "q", "v"]
 
     @staticmethod
     def _negative_log_likelihood(

--- a/lifetimes/fitters/pareto_nbd_fitter.py
+++ b/lifetimes/fitters/pareto_nbd_fitter.py
@@ -51,6 +51,7 @@ class ParetoNBDFitter(BaseFitter):
         """
 
         self.penalizer_coef = penalizer_coef
+        self.params_names = ["r", "alpha", "s", "beta"]
 
     def fit(
         self,

--- a/lifetimes/fitters/pareto_nbd_fitter.py
+++ b/lifetimes/fitters/pareto_nbd_fitter.py
@@ -518,6 +518,27 @@ class ParetoNBDFitter(BaseFitter):
         minimize_options["maxiter"] = maxiter
         minimize_options.update(kwargs)
 
+        self.solution_iter = []
+        def callback_solution_saver(
+            xk
+        ):
+            """
+            Instantiated inside ``scipy.optimize`` ``minimize()`` call 
+            inside the ``_fit()`` method.
+
+            Saves the solution at the fitter's ``solution_iter`` property.
+
+            Note that neither ``exp()`` nor scaling to ``alpha`` are applied here.
+            For those operations, use the ``solution_iter_summary`` property.
+
+            Parameters
+            ----------
+            xk : array-like
+                Solution at the current iteration.
+            """
+
+            self.solution_iter.append(xk.tolist())
+
         total_count = 0
         while total_count < iterative_fitting:
             current_init_params = (
@@ -533,9 +554,11 @@ class ParetoNBDFitter(BaseFitter):
                 x0=current_init_params,
                 args=minimizing_function_args,
                 options=minimize_options,
+                callback=callback_solution_saver
             )
             sols.append(output.x)
             ll.append(output.fun)
+            self.nit = output.nit # Number of Iterations performed
 
             total_count += 1
         argmin_ll, min_ll = min(enumerate(ll), key=lambda x: x[1])

--- a/lifetimes/plotting.py
+++ b/lifetimes/plotting.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+"""plots, lots of plots"""
+
 import numpy as np
 import pandas as pd
 from lifetimes.utils import calculate_alive_path, expected_cumulative_transactions
@@ -19,6 +21,10 @@ __all__ = [
 
 
 def coalesce(*args):
+    """
+    Creates a generator for the parameters.
+    """
+
     return next(s for s in args if s is not None)
 
 
@@ -51,8 +57,8 @@ def plot_period_transactions(
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     labels = kwargs.pop("label", ["Actual", "Model"])
@@ -71,11 +77,16 @@ def plot_period_transactions(
     plt.title(title)
     plt.ylabel(ylabel)
     plt.xlabel(xlabel)
+
     return ax
 
 
 def plot_calibration_purchases_vs_holdout_purchases(
-    model, calibration_holdout_matrix, kind="frequency_cal", n=7, **kwargs
+    model, 
+    calibration_holdout_matrix, 
+    kind="frequency_cal", 
+    n=7, 
+    **kwargs
 ):
     """
     Plot calibration purchases vs holdout.
@@ -98,8 +109,8 @@ def plot_calibration_purchases_vs_holdout_purchases(
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     x_labels = {
@@ -171,8 +182,8 @@ def plot_frequency_recency_matrix(
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     if max_frequency is None:
@@ -244,8 +255,8 @@ def plot_probability_alive_matrix(
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     z = model.conditional_probability_alive_matrix(max_frequency, max_recency)
@@ -298,8 +309,8 @@ def plot_expected_repeat_purchases(
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     if ax is None:
@@ -323,6 +334,7 @@ def plot_expected_repeat_purchases(
     plt.title(title)
     plt.xlabel(xlabel)
     plt.legend(loc="lower right")
+
     return ax
 
 
@@ -352,8 +364,8 @@ def plot_history_alive(model, t, transactions, datetime_col, freq="D", start_dat
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     if start_date is None:
@@ -446,8 +458,8 @@ def plot_cumulative_transactions(
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     if ax is None:
@@ -474,6 +486,7 @@ def plot_cumulative_transactions(
     ax.axvline(x=x_vline, color="r", linestyle="--")
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
+
     return ax
 
 
@@ -534,8 +547,8 @@ def plot_incremental_transactions(
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     if ax is None:
@@ -564,6 +577,7 @@ def plot_incremental_transactions(
     ax.axvline(x=x_vline, color="r", linestyle="--")
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
+
     return ax
 
 
@@ -594,8 +608,8 @@ def plot_transaction_rate_heterogeneity(
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     r, alpha = model._unload_params("r", "alpha")
@@ -615,6 +629,7 @@ def plot_transaction_rate_heterogeneity(
 
     fig.tight_layout(rect=[0, 0.03, 1, 0.95])
     plt.plot(x, rv.pdf(x), **kwargs)
+
     return ax
 
 
@@ -647,8 +662,8 @@ def plot_dropout_rate_heterogeneity(
     Returns
     -------
     axes: matplotlib.AxesSubplot
-
     """
+
     from matplotlib import pyplot as plt
 
     a, b = model._unload_params("a", "b")
@@ -668,6 +683,7 @@ def plot_dropout_rate_heterogeneity(
 
     fig.tight_layout(rect=[0, 0.03, 1, 0.95])
     plt.plot(x, rv.pdf(x), **kwargs)
+
     return ax
 
 
@@ -782,6 +798,10 @@ def plot_fitter_params(
 
 
 def forceAspect(ax, aspect=1):
+    """
+    Forces an aspect to the plots.
+    """
+
     im = ax.get_images()
     extent = im[0].get_extent()
     ax.set_aspect(abs((extent[1] - extent[0]) / (extent[3] - extent[2])) / aspect)

--- a/lifetimes/plotting.py
+++ b/lifetimes/plotting.py
@@ -671,6 +671,116 @@ def plot_dropout_rate_heterogeneity(
     return ax
 
 
+def plot_fitter_log_params(
+    model,
+    xlabel="iteration",
+    ylabel="value of the parameter",
+    title="Parameters Convergence before Any Transformations",
+    ax=None,
+    figsize=(8, 6),
+    **kwargs
+):
+    """
+    Plots the fitter's approximated log of the parameters convergence.
+
+    Parameters
+    ----------
+    model: lifetimes model
+        A fitted lifetimes model, for now only for BG/NBD
+    title: str, optional
+        Figure title
+    xlabel: str, optional
+        Figure xlabel
+    ylabel: str, optional
+        Figure ylabel
+    ax: matplotlib.AxesSubplot, optional
+        Using user axes
+    figsize: tuple
+        size of the image
+    kwargs
+        Passed into the pandas.DataFrame.plot command.
+
+    Returns
+    -------
+    axes: matplotlib.AxesSubplot
+    """
+
+    from matplotlib import pyplot as plt
+
+    if ax is None:
+        fig, ax = plt.subplots(1, 1, figsize = figsize)
+
+    plt.plot(model.solution_iter)
+
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+
+    plt.legend(model.params_names)
+
+    return ax
+
+
+def plot_fitter_params(
+    model,
+    xlabel="iteration",
+    ylabel="value of the parameter",
+    title="Iterative Convergence of the Fitter's Parameters",
+    figsize=(15, 15),
+    ax=None,
+    **kwargs
+):
+    """
+    Plots the fitter's approximated parameters convergence.
+
+    Parameters
+    ----------
+    model: lifetimes model
+        A fitted lifetimes model, for now only for BG/NBD
+    title: str, optional
+        Figure title
+    xlabel: str, optional
+        Figure xlabel
+    ylabel: str, optional
+        Figure ylabel
+    ax: matplotlib.AxesSubplot, optional
+        Using user axes
+    kwargs
+        Passed into the pandas.DataFrame.plot command.
+
+    Returns
+    -------
+    axes: matplotlib.AxesSubplot
+    """
+
+    from matplotlib import pyplot as plt
+
+    nrows, ncols = 2, 2
+    fig, axes = plt.subplots(nrows, ncols, figsize = figsize)
+
+    subplot_counter = 0
+    params = model.solution_iter_summary.columns
+    for i in range(nrows):
+        for j in range(ncols):
+
+            if subplot_counter < len(params):
+                ax = axes[i, j]
+                param = params[subplot_counter]
+
+                ax.plot(
+                    model.solution_iter_summary[param],
+                    label = param,
+                )
+
+                ax.set_xlabel('iteration')
+                ax.set_ylabel('value of the parameter')
+                ax.set_title('Iterative Convergence of Parameter {}'.format(param))
+
+                subplot_counter += 1
+
+    return axes
+
+
 def forceAspect(ax, aspect=1):
     im = ax.get_images()
     extent = im[0].get_extent()


### PR DESCRIPTION
Essentially, this *PR* creates **fitter properties that track the parameters' convergence**. This way the user will be able to debug the fitting visually and numerically.

Other subfeatures introduced are:

1. A new `benchmarks` folder with scripts that would test the benchmarked use cases, such as the one on the `Quickstart` web page and the `CDNOW` dataset. On later *PR*s I will store useful scripts there.
    - The `images` subfolder is ignored within the `.gitignore` file.
1. Plots for the fitters' parameters before and after exponentiation were added.

On a sidenote, I would like to point out the somewhat weird behavior I've obtained for the Pareto/NBD fitter on the `Quickstart` artificial data &mdash; maybe that's why Fader complains about fitting it? &mdash;:

![Pareto/NBD Parameters Convergence](https://user-images.githubusercontent.com/11823725/60832612-af4f0780-a192-11e9-99cf-bc40318817ba.png)
