### PR TITLE
Basic Docker Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ target/
 
 # VS Code
 .vscode/
+
+# Benchmarks
+benchmarks/images/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+####################################################################
+# Original Image
+####################################################################
+
+# This image can be changed to a simpler one:
+FROM python:3.6
+
+####################################################################
+# Documentation
+####################################################################
+
+# You can change this:
+LABEL author = "philippefanaro@gmail.com"
+
+# When building:
+
+# sudo docker build -t lifetimes .
+
+# To run it with a volume (example):
+
+# sudo docker run -v /home/<user_name>/lifetimes/:/usr/share/local_lifetimes -p 80:80 -it lifetimes
+
+####################################################################
+# Setup
+####################################################################
+
+RUN pip install -I scipy==1.1.0                                 && \
+    pip install matplotlib                                      && \
+    pip install seaborn                                         && \
+    # pip install lifetimes                                       && \
+    # Sphinx Docs (Optional):
+    pip install sphinx-rtd-theme                                && \                                  && \
+    pip install sphinxcontrib-napoleon                          && \
+    pip install recommonmark                                    && \
+    pip install sphinxcontrib-bibtex                            
+
+####################################################################
+# Adding Source Code to the Docker
+####################################################################
+
+# Para quando estiver em produção e não precisar mais montar volume:
+
+# COPY . /lifetimes
+
+####################################################################
+# Initial Commands
+####################################################################
+
+# `pip install -e .` installs your local version of the library
+# overriding the initial installation
+
+CMD cd /usr/share/local_lifetimes                               && \
+    pip install -e .                                            && \
+    /bin/bash                             

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,13 @@
+# On reproducing this locally
+
+If you fork/clone the library locally, also install it locally so you can create your own alterations and then perhaps contribute to the main project:
+
+```bash
+pip install -e .
+```
+
+This will overwrite the current `lifetimes` installation also. Any changes you make you automatically occur to the Python import, so you don't need to install it everytime you change something.
+
+# Internal Folders
+
+The `images` folder is supposed to have the images produced by the several `benchmarks` routines. However, the images won't be tracked by `git`. If you wish to get the images, simply run the scripts. (You will be able to see the relevant ones in the docs pages eventually.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+
+services:
+
+  lifetimes:
+
+    # In order to run the lifetimes Dockerfile (service) separately: sudo docker-compose lifetimes
+
+    # The configurations below are basically the same as:
+    # sudo docker run -v /home/${USER}/lifetimes/:/usr/share/local_lifetimes -p 80:80 -it lifetimes
+
+    build: 
+      context: .
+      dockerfile: Dockerfile
+#     command: > # can override the Dockerfile commands here
+    ports:
+      - target: 5000
+        published: 5000
+    networks:
+      - lifetimes-net
+    volumes:
+      - /home/philippe/Desktop/lifetimes:/usr/share/local_lifetimes
+
+networks:
+  lifetimes-net:
+
+volumes: # Estes volumes são criados e não conectados a volumes externos ao docker-compose (?)
+  lifetimes-vol:


### PR DESCRIPTION
The `4` modified/added files are:

- `.gitignore` : added a line to ignore the `benchmarks/images/` folder. Images there do not need to be tracked. The scripts in that folder should be reproducible locally.
- `Dockerfile` and `docker-compose.yml` : docker files to create standardized environments for the `Lifetimes` library. Hopefully, it will help circumvent installation problems.
- `README.md` : this is a simple readme file inside the `benchmarks/` folder.