### PR TITLE
Docs Explaining the `expected_cumulative_transactions()` Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ target/
 
 # VS Code
 .vscode/
+
+# Benchmarks Images
+benchmarks/images

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -540,6 +540,7 @@ def expected_cumulative_transactions(
     ----------
     .. [1] Fader, Peter S., Bruce G.S. Hardie, and Ka Lok Lee (2005),
     A Note on Implementing the Pareto/NBD Model in MATLAB.
+    http://brucehardie.com/notes/008/
     """
     
     start_date = pd.to_datetime(transactions[datetime_col], format=datetime_format).min()


### PR DESCRIPTION
After spending way more hours than I thought would be necessary to understand how the *incremental* and *cumulative* plots were made, I've come across the biggest part of the puzzle that was the `expected_cumulative_transactions()`. Other people also seem puzzled, given some comments I've seen in issues (e.g. #275).

Essentially, in the end, I had to track down some commits on `utils.py`, issues and pull requests. Out of all of them, the most enlightening one was issue #99. There @aprotopopov mentions a [link](https://rdrr.io/cran/BTYD/man/bgbb.PlotTrackingCum.html) to the sister plot in the [BTYD](https://cran.r-project.org/web/packages/BTYD/index.html) library. In the function *References Section*, you can see a link to one of Hardie's papers. **However**, Hardie's document that really has the understandable formulation to implement this is his [Note #008](http://brucehardie.com/notes/008/) (more specifically, around the equation on page 8) on , entitled *A Note on Implementing the Pareto/NBD Model in MATLAB*.

@aprotopopov, can you confirm my explanation of the function?