### PR TITLE
doc change: `cumulative` to `incremental` misleading compare to `plot…

### DIFF
--- a/lifetimes/plotting.py
+++ b/lifetimes/plotting.py
@@ -494,7 +494,7 @@ def plot_incremental_transactions(
     **kwargs
 ):
     """
-    Plot a figure of the predicted and actual cumulative transactions of users.
+    Plot a figure of the predicted and actual incremental transactions of users.
 
     Parameters
     ----------


### PR DESCRIPTION
…_cumulative_transactions()`

documentation description for `plot_incremental_transactions()` is the same as `plot_cumulative_transactions()`, suspect copied over but forget to change.