### PR TITLE
Add license to dist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+license_file=LICENSE.txt
+
 [pep8]
 ignore=E501,E241
 


### PR DESCRIPTION
Currently `LICENSE.txt` is not packaged with releases. Adding this to fulfill the requirement of conda release.