### PR TITLE
More numerically stable log likelihood calculation for beta_geo_fitter

### DIFF
--- a/lifetimes/fitters/beta_geo_fitter.py
+++ b/lifetimes/fitters/beta_geo_fitter.py
@@ -191,8 +191,10 @@ class BetaGeoFitter(BaseFitter):
         A_3 = -(r + freq) * np.log(alpha + T)
         A_4 = np.log(a) - np.log(b + np.maximum(freq, 1) - 1) - (r + freq) * np.log(rec + alpha)
 
+        max_A_3_A_4 = np.maximum(A_3, A_4)
+
         penalizer_term = penalizer_coef * sum(params ** 2)
-        ll = weights * (A_1 + A_2 + np.log(np.exp(A_3) + np.exp(A_4) * (freq > 0)))
+        ll = weights * (A_1 + A_2 + np.log(np.exp(A_3 - max_A_3_A_4) + np.exp(A_4 - max_A_3_A_4) * (freq > 0)) + max_A_3_A_4)
 
         return -ll.sum() / weights.sum() + penalizer_term
 


### PR DESCRIPTION
I ran into issues when using BetaGeoFitter from v0.11.1. 

The parameter estimates I was getting did not make sense (I was getting r=a=b=1.105171 and alpha=2295.439997 and NaN for se(coef) when looking at the summary). 

The reason for this was that in the computation of `ll` in the `_negative_log_likelihood` it was hitting inf for some values when computing `np.exp(A_3)` and `np.exp(A_4)`. Since we eventually compute the log of the sum of these two terms, we can avoid hitting inf by subtracting the largest of A_3 and A_4 when doing np.exp() and then adding it back outside of the np.log().  This leaves the expression mathematically the same, but since np.exp() is done on much smaller numbers, then you would avoid running into the numerical issues caused by doing np.exp() on large numbers.

This change is possibly a solution for this currently open issue: https://github.com/CamDavidsonPilon/lifetimes/issues/262