### PR TITLE
Explicitly use utf8 to pass conda-forge Windows build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import io
 import os
 from setuptools import setup
 
@@ -10,7 +11,7 @@ exec(compile(open("lifetimes/version.py").read(), "lifetimes/version.py", "exec"
 readme_path = os.path.join(os.path.dirname(__file__), "README.md")
 
 
-long_description = open(readme_path).read()
+long_description = io.open(readme_path, encoding="utf8").read()
 
 
 setup(


### PR DESCRIPTION
Python read io in windows builds started to use CP1252 instead of UTF-8, which are [failing](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=181730&view=logs&j=171a126d-c574-5c8c-1269-ff3b989e923d&t=1183ba29-a0b5-5324-8463-2a49ace9e213).

`io.open` ensures compatibility between py2 and py3