### PR TITLE
Fix infavorable numpy version in build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
    - "3.5"
    - "3.6"
 env:
-   - PANDAS_VERSION=0.24.1
+  - PANDAS_VERSION=0.24.1
 # Enable newer 3.7 without globally enabling sudo and dist: xenial for other build jobs
 matrix:
   include:
@@ -17,7 +17,7 @@ matrix:
 before_install:
   - ls
 install:
-  - "pip install -r dev_requirements.txt"
+  - "pip install -r dev_requirements.txt --upgrade"
   - "pip install pandas==$PANDAS_VERSION"
   - "pip freeze --local"
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,20 @@ python:
    - "3.5"
    - "3.6"
 env:
-- export PANDAS_VERSION=0.24.1
+   - PANDAS_VERSION=0.24.1
 # Enable newer 3.7 without globally enabling sudo and dist: xenial for other build jobs
 matrix:
   include:
   - python: 3.7
     dist: xenial
     sudo: true
-    env: export PANDAS_VERSION=0.24.1
+    env: PANDAS_VERSION=0.24.1
 before_install:
   - ls
 install:
   - "pip install -r dev_requirements.txt"
   - "pip install pandas==$PANDAS_VERSION"
+  - "pip freeze --local"
 # command to run tests
 script:
   - py.test --cov lifetimes


### PR DESCRIPTION
Force updating the cached pip dep environment in travis seems to fix the py3.6 build.
The former cached `numpy` version was too old (1.13.3) compared to other envs in the build matrix (1.15.0)

We can add more version pinning if needed, like the pin for `pandas`.
