### PR TITLE
Description of plot_expected_repeat_purchases

### DIFF
--- a/lifetimes/plotting.py
+++ b/lifetimes/plotting.py
@@ -282,8 +282,6 @@ def plot_expected_repeat_purchases(
     ----------
     model: lifetimes model
         A fitted lifetimes model.
-    max_frequency: int, optional
-        The maximum frequency to plot.
     title: str, optional
         Figure title
     xlabel: str, optional


### PR DESCRIPTION
plot_expected_repeat_purchases does not accept max_frequency as a parameter. However, the description claimed it did. I erased the line in the description claiming max_frequency was a valid parameter.