### PR TITLE
Fixed Gamma-Gamma / ParetoNBD Bug

### DIFF
--- a/lifetimes/fitters/gamma_gamma_fitter.py
+++ b/lifetimes/fitters/gamma_gamma_fitter.py
@@ -289,6 +289,8 @@ class GammaGammaFitter(BaseFitter):
             lifetime values as values
         """
 
+        frequency, recency, T, monetary_value = np.asarray(frequency), np.asarray(recency), np.asarray(T), np.asarray(monetary_value)
+
         # use the Gamma-Gamma estimates for the monetary_values
         adjusted_monetary_value = self.conditional_expected_average_profit(frequency, monetary_value)
 

--- a/lifetimes/utils.py
+++ b/lifetimes/utils.py
@@ -486,7 +486,7 @@ def _customer_lifetime_value(
         series with customer ids as index and the estimated customer lifetime values as values
     """
 
-    df = pd.DataFrame(index=frequency.index)
+    df = pd.DataFrame(index=range(len(frequency)))
     df["clv"] = 0  # initialize the clv column to zeros
 
     steps = np.arange(1, time + 1)


### PR DESCRIPTION
As per [this issue](https://github.com/CamDavidsonPilon/lifetimes/issues/423), users have had problems using GammaGammaFitter when fitted with the ParetoNBD model and calling `customer_lifetime_value`. These stem from mixed DataFrame/Series inputs, and are most easily fixed by converting the inputs to arrays early on. There are two changes:
- Editing the DataFrame instantiation in utils._customer_lifetime_value to not use the `.index` attribute, and not require a DataFrame/Series object as input. This is more consistent with the functions docstring, which specifies an 'array-like' as input
- Converting all the inputs of `GammaGammaFitter().customer_lifetime_value()` to ndarrays. This avoids the issues linked, regardless of user input.